### PR TITLE
feat: padronização de filtros de ano e correção de navegação

### DIFF
--- a/src/components/navigation/EducationSelection.jsx
+++ b/src/components/navigation/EducationSelection.jsx
@@ -1,66 +1,74 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import { Typography, Container } from '@mui/material';
-import { FaGraduationCap, FaChartLine, FaUniversity, FaMapMarkedAlt } from 'react-icons/fa';
-import { useTheme } from '@mui/material/styles';
-import { Button, Card } from '../ui';
+import React from "react";
+import { Link } from "react-router-dom";
+import { Typography, Container } from "@mui/material";
+import {
+  FaGraduationCap,
+  FaChartLine,
+  FaUniversity,
+  FaMapMarkedAlt,
+} from "react-icons/fa";
+import { useTheme } from "@mui/material/styles";
+import { Button, Card } from "../ui";
 
 const EducationSelection = () => {
   const theme = useTheme();
-  
+
   return (
-    <Container sx={{ padding: '2rem 0', maxWidth: '1200px' }}>
-      <Typography 
-        variant="h4" 
-        component="h1" 
-        gutterBottom 
+    <Container sx={{ padding: "2rem 0", maxWidth: "1200px" }}>
+      <Typography
+        variant="h4"
+        component="h1"
+        gutterBottom
         sx={{
           color: theme.palette.primary.main,
           fontWeight: 500,
-          textAlign: 'center',
+          textAlign: "center",
           marginBottom: 2,
         }}
       >
         Dados Educacionais
       </Typography>
-      <Typography 
-        variant="subtitle1" 
-        gutterBottom 
+      <Typography
+        variant="subtitle1"
+        gutterBottom
         sx={{
           color: theme.palette.text.secondary,
-          textAlign: 'center',
+          textAlign: "center",
           marginBottom: 3,
         }}
       >
         Selecione o tipo de dados educacionais que deseja visualizar
       </Typography>
-      
-      <div 
+
+      <div
         style={{
-          display: 'flex',
-          flexDirection: 'row',
-          gap: '24px',
-          justifyContent: 'center',
-          alignItems: 'stretch',
-          marginTop: '16px',
-          flexWrap: 'wrap'
+          display: "flex",
+          flexDirection: "row",
+          gap: "24px",
+          justifyContent: "center",
+          alignItems: "stretch",
+          marginTop: "16px",
+          flexWrap: "wrap",
         }}
       >
         {/* Card 1 - Educação Básica */}
-        <div 
+        <div
           style={{
-            flex: '1 1 300px',
-            maxWidth: '350px',
-            minWidth: '250px'
+            flex: "1 1 300px",
+            maxWidth: "350px",
+            minWidth: "250px",
           }}
         >
           <Card variant="elevated" className="h-full">
-            <Card.Content padding="large" className="flex flex-col items-center text-center justify-between">
-              <FaGraduationCap 
-                style={{ 
+            <Card.Content
+              padding="large"
+              className="flex flex-col items-center text-center justify-between"
+            >
+              <FaGraduationCap
+                style={{
                   color: theme.palette.primary.main,
-                  fontSize: '4rem',
-                  marginBottom: '1.5rem'
+                  fontSize: "4rem",
+                  marginBottom: "1.5rem",
                 }}
               />
               <Typography variant="h6" component="h2" gutterBottom>
@@ -69,9 +77,9 @@ const EducationSelection = () => {
               <Typography variant="body2" color="textSecondary">
                 Educação Infantil, Fundamental e Médio
               </Typography>
-              <Button 
-                component={Link} 
-                to="/dados-educacionais/basica" 
+              <Button
+                component={Link}
+                to="/dados-educacionais/basica"
                 variant="primary"
                 size="medium"
                 className="mt-4"
@@ -83,20 +91,23 @@ const EducationSelection = () => {
         </div>
 
         {/* Card 2 - Censo Escolar */}
-        <div 
+        <div
           style={{
-            flex: '1 1 300px',
-            maxWidth: '350px',
-            minWidth: '250px'
+            flex: "1 1 300px",
+            maxWidth: "350px",
+            minWidth: "250px",
           }}
         >
           <Card variant="elevated" className="h-full">
-            <Card.Content padding="large" className="flex flex-col items-center text-center justify-between">
-              <FaMapMarkedAlt 
-                style={{ 
+            <Card.Content
+              padding="large"
+              className="flex flex-col items-center text-center justify-between"
+            >
+              <FaMapMarkedAlt
+                style={{
                   color: theme.palette.primary.main,
-                  fontSize: '4rem',
-                  marginBottom: '1.5rem'
+                  fontSize: "4rem",
+                  marginBottom: "1.5rem",
                 }}
               />
               <Typography variant="h6" component="h2" gutterBottom>
@@ -105,9 +116,9 @@ const EducationSelection = () => {
               <Typography variant="body2" color="textSecondary">
                 Infraestrutura Escolar
               </Typography>
-              <Button 
-                component={Link} 
-                to="/dados-educacionais/condicoes-de-oferta" 
+              <Button
+                component={Link}
+                to="/dados-educacionais/condicoes-de-oferta"
                 variant="primary"
                 size="medium"
                 className="mt-4"
@@ -117,22 +128,25 @@ const EducationSelection = () => {
             </Card.Content>
           </Card>
         </div>
-        
+
         {/* Card 3 - Educação Superior */}
-        <div 
+        <div
           style={{
-            flex: '1 1 300px',
-            maxWidth: '350px',
-            minWidth: '250px'
+            flex: "1 1 300px",
+            maxWidth: "350px",
+            minWidth: "250px",
           }}
         >
           <Card variant="elevated" className="h-full">
-            <Card.Content padding="large" className="flex flex-col items-center text-center justify-between">
-              <FaUniversity 
-                style={{ 
+            <Card.Content
+              padding="large"
+              className="flex flex-col items-center text-center justify-between"
+            >
+              <FaUniversity
+                style={{
                   color: theme.palette.primary.main,
-                  fontSize: '4rem',
-                  marginBottom: '1.5rem'
+                  fontSize: "4rem",
+                  marginBottom: "1.5rem",
                 }}
               />
               <Typography variant="h6" component="h2" gutterBottom>
@@ -141,9 +155,9 @@ const EducationSelection = () => {
               <Typography variant="body2" color="textSecondary">
                 Matrículas e Dados Institucionais
               </Typography>
-              <Button 
-                component={Link} 
-                to="/dados-educacionais/superior" 
+              <Button
+                component={Link}
+                to="/dados-educacionais/superior"
                 variant="primary"
                 size="medium"
                 className="mt-4"
@@ -153,22 +167,25 @@ const EducationSelection = () => {
             </Card.Content>
           </Card>
         </div>
-        
+
         {/* Card 4 - Taxas Educacionais */}
-        <div 
+        <div
           style={{
-            flex: '1 1 300px',
-            maxWidth: '350px',
-            minWidth: '250px'
+            flex: "1 1 300px",
+            maxWidth: "350px",
+            minWidth: "250px",
           }}
         >
           <Card variant="elevated" className="h-full">
-            <Card.Content padding="large" className="flex flex-col items-center text-center justify-between">
-              <FaChartLine 
-                style={{ 
+            <Card.Content
+              padding="large"
+              className="flex flex-col items-center text-center justify-between"
+            >
+              <FaChartLine
+                style={{
                   color: theme.palette.primary.main,
-                  fontSize: '4rem',
-                  marginBottom: '1.5rem'
+                  fontSize: "4rem",
+                  marginBottom: "1.5rem",
                 }}
               />
               <Typography variant="h6" component="h2" gutterBottom>
@@ -177,9 +194,9 @@ const EducationSelection = () => {
               <Typography variant="body2" color="textSecondary">
                 Taxas de Aprovação, Reprovação, Abandono e Distorção Idade-Série
               </Typography>
-              <Button 
-                component={Link} 
-                to="/dados-educacionais/indicadores" 
+              <Button
+                component={Link}
+                to="/dados-educacionais/taxas"
                 variant="primary"
                 size="medium"
                 className="mt-4"

--- a/src/components/pages/education/basic/CensoEscolarFilterComponent.jsx
+++ b/src/components/pages/education/basic/CensoEscolarFilterComponent.jsx
@@ -1,10 +1,13 @@
-import React, { useMemo, useEffect, useState } from 'react';
-import { Button, Collapse } from '@mui/material';
-import { ExpandMore, ExpandLess } from '@mui/icons-material';
-import { Select } from '../../../ui';
-import YearRangeSlider from '../../../ui/YearRangeSlider';
-import { municipios, Regioes, FaixaPopulacional } from '../../../../utils/citiesMapping';
-
+import React, { useMemo, useEffect, useState } from "react";
+import { Button, Collapse } from "@mui/material";
+import { ExpandMore, ExpandLess } from "@mui/icons-material";
+import { Select } from "../../../ui";
+import YearRangeSlider from "../../../ui/YearRangeSlider";
+import {
+  municipios,
+  Regioes,
+  FaixaPopulacional,
+} from "../../../../utils/citiesMapping";
 
 function CensoEscolarFilterComponent({
   city,
@@ -26,21 +29,29 @@ function CensoEscolarFilterComponent({
   const [filtersExpanded, setFiltersExpanded] = useState(false);
   const [yearRange, setYearRange] = useState([2007, 2024]);
 
-  const cityOptions = Object.entries(municipios).map(([key, { nomeMunicipio }]) => ({
-    value: key,
-    label: nomeMunicipio,
-  }));
+  const cityOptions = Object.entries(municipios).map(
+    ([key, { nomeMunicipio }]) => ({
+      value: key,
+      label: nomeMunicipio,
+    }),
+  );
 
   const baseFilteredMunicipios = useMemo(() => {
     const territoryLabel = territory ? Regioes[territory] : null;
-    const faixaLabel = faixaPopulacional ? FaixaPopulacional[faixaPopulacional] : null;
+    const faixaLabel = faixaPopulacional
+      ? FaixaPopulacional[faixaPopulacional]
+      : null;
 
     return Object.values(municipios).filter((m) => {
-      if (territoryLabel && m.territorioDesenvolvimento !== territoryLabel) return false;
+      if (territoryLabel && m.territorioDesenvolvimento !== territoryLabel)
+        return false;
       if (faixaLabel && m.faixaPopulacional !== faixaLabel) return false;
-      if (aglomerado && String(m.aglomerado) !== String(aglomerado)) return false;
+      if (aglomerado && String(m.aglomerado) !== String(aglomerado))
+        return false;
       if (gerencia) {
-        const gerencias = String(m.gerencia).split(',').map((g) => g.trim());
+        const gerencias = String(m.gerencia)
+          .split(",")
+          .map((g) => g.trim());
         if (!gerencias.includes(String(gerencia))) return false;
       }
       return true;
@@ -50,36 +61,59 @@ function CensoEscolarFilterComponent({
   const filteredCityOptions = useMemo(() => {
     return Object.entries(municipios)
       .filter(([, m]) => baseFilteredMunicipios.includes(m))
-      .map(([key, { nomeMunicipio }]) => ({ value: key, label: nomeMunicipio }));
+      .map(([key, { nomeMunicipio }]) => ({
+        value: key,
+        label: nomeMunicipio,
+      }));
   }, [baseFilteredMunicipios]);
 
   const filteredTerritorioOptions = useMemo(() => {
-    const uniqueLabels = [...new Set(baseFilteredMunicipios.map((m) => m.territorioDesenvolvimento).filter(Boolean))];
+    const uniqueLabels = [
+      ...new Set(
+        baseFilteredMunicipios
+          .map((m) => m.territorioDesenvolvimento)
+          .filter(Boolean),
+      ),
+    ];
     return Object.entries(Regioes)
       .filter(([, label]) => uniqueLabels.includes(label))
       .map(([id, label]) => ({ value: id, label }));
   }, [baseFilteredMunicipios]);
 
   const filteredFaixaPopulacionalOptions = useMemo(() => {
-    const uniqueLabels = [...new Set(baseFilteredMunicipios.map((m) => m.faixaPopulacional).filter(Boolean))];
+    const uniqueLabels = [
+      ...new Set(
+        baseFilteredMunicipios.map((m) => m.faixaPopulacional).filter(Boolean),
+      ),
+    ];
     return Object.entries(FaixaPopulacional)
       .filter(([, label]) => uniqueLabels.includes(label))
       .map(([id, label]) => ({ value: id, label }));
   }, [baseFilteredMunicipios]);
 
   const filteredAglomeradoOptions = useMemo(() => {
-    return [...new Set(baseFilteredMunicipios.map((m) => m.aglomerado).filter((a) => a && a !== 'undefined'))]
+    return [
+      ...new Set(
+        baseFilteredMunicipios
+          .map((m) => m.aglomerado)
+          .filter((a) => a && a !== "undefined"),
+      ),
+    ]
       .sort((a, b) => Number(a) - Number(b))
       .map((a) => ({ value: a, label: `AG ${a}` }));
   }, [baseFilteredMunicipios]);
 
   const filteredGerenciaOptions = useMemo(() => {
-    return [...new Set(
-      baseFilteredMunicipios
-        .map((m) => m.gerencia)
-        .filter((g) => g && g !== 'undefined')
-        .flatMap((g) => (g.includes(',') ? g.split(',').map((x) => x.trim()) : [g]))
-    )]
+    return [
+      ...new Set(
+        baseFilteredMunicipios
+          .map((m) => m.gerencia)
+          .filter((g) => g && g !== "undefined")
+          .flatMap((g) =>
+            g.includes(",") ? g.split(",").map((x) => x.trim()) : [g],
+          ),
+      ),
+    ]
       .sort((a, b) => Number(a) - Number(b))
       .map((g) => ({ value: g, label: `${g}ª GRE` }));
   }, [baseFilteredMunicipios]);
@@ -91,7 +125,7 @@ function CensoEscolarFilterComponent({
       if (value && options.length > 0) {
         const exists = options.some((opt) => opt.value === value);
         if (!exists) {
-          setter('');
+          setter("");
         }
       }
     }, [value, setter, options]);
@@ -99,24 +133,33 @@ function CensoEscolarFilterComponent({
 
   useClearInvalidFilter(city, setCity, filteredCityOptions);
   useClearInvalidFilter(territory, setTerritory, filteredTerritorioOptions);
-  useClearInvalidFilter(faixaPopulacional, setFaixaPopulacional, filteredFaixaPopulacionalOptions);
+  useClearInvalidFilter(
+    faixaPopulacional,
+    setFaixaPopulacional,
+    filteredFaixaPopulacionalOptions,
+  );
   useClearInvalidFilter(aglomerado, setAglomerado, filteredAglomeradoOptions);
   useClearInvalidFilter(gerencia, setGerencia, filteredGerenciaOptions);
 
   useEffect(() => {
     if (city) {
-      setTerritory('');
-      setFaixaPopulacional('');
-      setAglomerado('');
-      setGerencia('');
+      setTerritory("");
+      setFaixaPopulacional("");
+      setAglomerado("");
+      setGerencia("");
     }
   }, [city]);
 
   const handleFilterClickWithYears = () => {
     const startYr = yearRange[0];
     const endYr = yearRange[1];
-    console.log('handleFilterClickWithYears - yearRange:', yearRange);
-    console.log('handleFilterClickWithYears - startYear:', startYr, 'endYear:', endYr);
+    console.log("handleFilterClickWithYears - yearRange:", yearRange);
+    console.log(
+      "handleFilterClickWithYears - startYear:",
+      startYr,
+      "endYear:",
+      endYr,
+    );
     handleFilterClick({
       selectedFilters,
       city,
@@ -134,7 +177,12 @@ function CensoEscolarFilterComponent({
       {/* Tipo + Botão Mais Filtros - Primeira linha */}
       <div className="flex flex-col lg:flex-row items-end gap-4">
         <div className="w-full lg:flex-1">
-          <label htmlFor="multiFilterSelect" className="block text-sm font-medium text-gray-700 mb-1">Tipo:</label>
+          <label
+            htmlFor="multiFilterSelect"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            Tipo:
+          </label>
           <Select
             id="multiFilterSelect"
             value={selectedFilters}
@@ -145,111 +193,160 @@ function CensoEscolarFilterComponent({
             size="xs"
           />
         </div>
-
-        <Button
-          variant="outlined"
-          size="small"
-          startIcon={filtersExpanded ? <ExpandLess /> : <ExpandMore />}
-          onClick={() => setFiltersExpanded(!filtersExpanded)}
-          sx={{
-            minWidth: 'auto',
-            padding: '8px 16px',
-            whiteSpace: 'nowrap',
-            height: 'fit-content',
-            width: { xs: '100%', lg: 'auto' }
-          }}
-        >
-          {filtersExpanded ? 'Menos Filtros' : 'Mais Filtros'}
-        </Button>
       </div>
 
-      {/* Filtros recolhíveis */}
-      <Collapse in={filtersExpanded} timeout="auto" unmountOnExit>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 pb-4 border-b border-gray-200">
-          {/* Território */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Território:</label>
-            <Select
-              id="territorySelect"
-              value={territory ? { value: territory, label: Regioes[territory] } : null}
-              onChange={(selectedOption) => setTerritory(selectedOption ? selectedOption.value : '')}
-              options={filteredTerritorioOptions}
-              placeholder="Território de Desenvolvimento"
-              size="xs"
-              isClearable
-              disabled={otherLocalityDisabled}
-            />
-          </div>
-
-          {/* Faixa Populacional */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Faixa Populacional:</label>
-            <Select
-              id="faixaPopulacionalSelect"
-              value={faixaPopulacional ? { value: faixaPopulacional, label: FaixaPopulacional[faixaPopulacional] } : null}
-              onChange={(selectedOption) => setFaixaPopulacional(selectedOption ? selectedOption.value : '')}
-              options={filteredFaixaPopulacionalOptions}
-              placeholder="Faixa Populacional"
-              size="xs"
-              isClearable
-              disabled={otherLocalityDisabled}
-            />
-          </div>
-
-          {/* Aglomerado */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Aglomerado:</label>
-            <Select
-              id="aglomeradoSelect"
-              value={aglomerado ? { value: aglomerado, label: `AG ${aglomerado}` } : null}
-              onChange={(selectedOption) => setAglomerado(selectedOption ? selectedOption.value : '')}
-              options={filteredAglomeradoOptions}
-              placeholder="Aglomerado - AG"
-              size="xs"
-              isClearable
-              disabled={otherLocalityDisabled}
-            />
-          </div>
-
-          {/* Gerência */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Gerência:</label>
-            <Select
-              id="gerenciaSelect"
-              value={gerencia ? { value: gerencia, label: `${gerencia}ª GRE` } : null}
-              onChange={(selectedOption) => setGerencia(selectedOption ? selectedOption.value : '')}
-              options={filteredGerenciaOptions}
-              placeholder="Gerência Regional de Ensino - GRE"
-              size="xs"
-              isClearable
-              disabled={otherLocalityDisabled}
-            />
-          </div>
-
-          {/* Município */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Município:</label>
-            <Select
-              id="citySelect"
-              value={(filteredCityOptions.length > 0 ? filteredCityOptions : cityOptions).find(option => option.value === city) || null}
-              onChange={(selectedOption) => setCity(selectedOption ? selectedOption.value : '')}
-              options={filteredCityOptions.length > 0 ? filteredCityOptions : cityOptions}
-              placeholder="Município"
-              size="xs"
-              isClearable
-            />
-          </div>
+      {/* Filtros visivel */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 pb-4 border-b border-gray-200">
+        {/* Território */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Território:
+          </label>
+          <Select
+            id="territorySelect"
+            value={
+              territory ? { value: territory, label: Regioes[territory] } : null
+            }
+            onChange={(selectedOption) =>
+              setTerritory(selectedOption ? selectedOption.value : "")
+            }
+            options={filteredTerritorioOptions}
+            placeholder="Território de Desenvolvimento"
+            size="xs"
+            isClearable
+            disabled={otherLocalityDisabled}
+          />
         </div>
-      </Collapse>
 
-      {/* Período - Range Slider */}
-      <div className="py-4">
-        <YearRangeSlider
-          minYear={2007}
-          maxYear={2024}
-          value={yearRange}
-          onChange={setYearRange}
-        />
+        {/* Faixa Populacional */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Faixa Populacional:
+          </label>
+          <Select
+            id="faixaPopulacionalSelect"
+            value={
+              faixaPopulacional
+                ? {
+                    value: faixaPopulacional,
+                    label: FaixaPopulacional[faixaPopulacional],
+                  }
+                : null
+            }
+            onChange={(selectedOption) =>
+              setFaixaPopulacional(selectedOption ? selectedOption.value : "")
+            }
+            options={filteredFaixaPopulacionalOptions}
+            placeholder="Faixa Populacional"
+            size="xs"
+            isClearable
+            disabled={otherLocalityDisabled}
+          />
+        </div>
+
+        {/* Aglomerado */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Aglomerado:
+          </label>
+          <Select
+            id="aglomeradoSelect"
+            value={
+              aglomerado
+                ? { value: aglomerado, label: `AG ${aglomerado}` }
+                : null
+            }
+            onChange={(selectedOption) =>
+              setAglomerado(selectedOption ? selectedOption.value : "")
+            }
+            options={filteredAglomeradoOptions}
+            placeholder="Aglomerado - AG"
+            size="xs"
+            isClearable
+            disabled={otherLocalityDisabled}
+          />
+        </div>
+
+        {/* Gerência */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Gerência:
+          </label>
+          <Select
+            id="gerenciaSelect"
+            value={
+              gerencia ? { value: gerencia, label: `${gerencia}ª GRE` } : null
+            }
+            onChange={(selectedOption) =>
+              setGerencia(selectedOption ? selectedOption.value : "")
+            }
+            options={filteredGerenciaOptions}
+            placeholder="Gerência Regional de Ensino - GRE"
+            size="xs"
+            isClearable
+            disabled={otherLocalityDisabled}
+          />
+        </div>
+
+        {/* Município */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Município:
+          </label>
+          <Select
+            id="citySelect"
+            value={
+              (filteredCityOptions.length > 0
+                ? filteredCityOptions
+                : cityOptions
+              ).find((option) => option.value === city) || null
+            }
+            onChange={(selectedOption) =>
+              setCity(selectedOption ? selectedOption.value : "")
+            }
+            options={
+              filteredCityOptions.length > 0 ? filteredCityOptions : cityOptions
+            }
+            placeholder="Município"
+            size="xs"
+            isClearable
+          />
+        </div>
+      </div>
+
+      {/* Período - Seleção de Anos (Substituindo o Slider) */}
+      <div className="py-4 flex flex-col sm:flex-row gap-4">
+        <div className="flex-1">
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            De:
+          </label>
+          <Select
+            id="startYearSelect"
+            value={{ value: yearRange[0], label: String(yearRange[0]) }}
+            options={Array.from({ length: 2024 - 2007 + 1 }, (_, i) => ({
+              value: 2007 + i,
+              label: String(2007 + i),
+            }))}
+            onChange={(opt) => setYearRange([opt.value, yearRange[1]])}
+            size="xs"
+          />
+        </div>
+
+        <div className="flex-1">
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Até:
+          </label>
+          <Select
+            id="endYearSelect"
+            value={{ value: yearRange[1], label: String(yearRange[1]) }}
+            options={Array.from({ length: 2024 - 2007 + 1 }, (_, i) => ({
+              value: 2007 + i,
+              label: String(2007 + i),
+            }))}
+            onChange={(opt) => setYearRange([yearRange[0], opt.value])}
+            size="xs"
+          />
+        </div>
       </div>
 
       {/* Botões */}
@@ -268,10 +365,10 @@ function CensoEscolarFilterComponent({
           onClick={handleClearFilters}
           className="w-full sm:w-auto"
           sx={{
-            backgroundColor: '#f0f0f0',
-            color: '#000',
-            '&:hover': {
-              backgroundColor: '#e0e0e0',
+            backgroundColor: "#f0f0f0",
+            color: "#000",
+            "&:hover": {
+              backgroundColor: "#e0e0e0",
             },
           }}
         >

--- a/src/components/pages/education/basic/ParentComponent.jsx
+++ b/src/components/pages/education/basic/ParentComponent.jsx
@@ -1,39 +1,46 @@
-import { ExpandLess, ExpandMore } from '@mui/icons-material';
-import { Button, Collapse, Switch, Typography } from '@mui/material';
-import { useTheme } from '@mui/material/styles';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { ExpandLess, ExpandMore } from "@mui/icons-material";
+import { Button, Collapse, Switch, Typography } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 // import { exportBasicEducationTable } from '../../../../services/exportTableService.jsx';
-import '../../../../style/RevenueTableContainer.css';
-import '../../../../style/TableFilters.css';
-import { FaixaPopulacional, municipios, Regioes } from '../../../../utils/citiesMapping';
-import { Loading, Select } from '../../../ui';
-import YearRangeSlider from '../../../ui/YearRangeSlider';
-import ApiContainer from './ApiComponent.jsx';
-import ApiDataTable from './apiDataTable.jsx';
+import "../../../../style/RevenueTableContainer.css";
+import "../../../../style/TableFilters.css";
+import {
+  FaixaPopulacional,
+  municipios,
+  Regioes,
+} from "../../../../utils/citiesMapping";
+import { Loading, Select } from "../../../ui";
+import YearRangeSlider from "../../../ui/YearRangeSlider";
+import ApiContainer from "./ApiComponent.jsx";
+import ApiDataTable from "./apiDataTable.jsx";
 
 function ParentComponent() {
   const apiRef = useRef();
-  const yearLimits = useMemo(() => ({
-    enrollment: { min: 2007, max: 2024 },
-    'school/count': { min: 2007, max: 2024 },
-    class: { min: 2007, max: 2024 },
-    teacher: { min: 2021, max: 2024 },
-    auxiliar: { min: 2007, max: 2024 },
-    employees: { min: 2007, max: 2024 }
-  }), []);
+  const yearLimits = useMemo(
+    () => ({
+      enrollment: { min: 2007, max: 2024 },
+      "school/count": { min: 2007, max: 2024 },
+      class: { min: 2007, max: 2024 },
+      teacher: { min: 2021, max: 2024 },
+      auxiliar: { min: 2007, max: 2024 },
+      employees: { min: 2007, max: 2024 },
+    }),
+    [],
+  );
 
-  const [type, setType] = useState('enrollment');
-  const [filteredType, setFilteredType] = useState('enrollment');
+  const [type, setType] = useState("enrollment");
+  const [filteredType, setFilteredType] = useState("enrollment");
   const [isHistorical, setIsHistorical] = useState(false);
-  const [city, setCity] = useState('');
-  const [territory, setTerritory] = useState('');
-  const [faixaPopulacional, setFaixaPopulacional] = useState('');
-  const [aglomerado, setAglomerado] = useState('');
-  const [gerencia, setGerencia] = useState('');
+  const [city, setCity] = useState("");
+  const [territory, setTerritory] = useState("");
+  const [faixaPopulacional, setFaixaPopulacional] = useState("");
+  const [aglomerado, setAglomerado] = useState("");
+  const [gerencia, setGerencia] = useState("");
   const [data, setData] = useState(null);
   const [error, setError] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [title, setTitle] = useState('');
+  const [title, setTitle] = useState("");
   const [selectedFilters, setSelectedFilters] = useState([]);
   const [isEtapaSelected, setIsEtapaSelected] = useState(false);
   const [isLocalidadeSelected, setIsLocalidadeSelected] = useState(false);
@@ -60,10 +67,10 @@ function ParentComponent() {
   const [yearRange, setYearRange] = useState([2007, 2024]);
 
   // Estados para armazenar os filtros aplicados na última busca
-  const [appliedTerritory, setAppliedTerritory] = useState('');
-  const [appliedFaixaPopulacional, setAppliedFaixaPopulacional] = useState('');
-  const [appliedAglomerado, setAppliedAglomerado] = useState('');
-  const [appliedGerencia, setAppliedGerencia] = useState('');
+  const [appliedTerritory, setAppliedTerritory] = useState("");
+  const [appliedFaixaPopulacional, setAppliedFaixaPopulacional] = useState("");
+  const [appliedAglomerado, setAppliedAglomerado] = useState("");
+  const [appliedGerencia, setAppliedGerencia] = useState("");
   const [appliedSelectedFilters, setAppliedSelectedFilters] = useState([]);
 
   const getYearLimits = useMemo(() => {
@@ -73,7 +80,7 @@ function ParentComponent() {
   const yearOptions = useMemo(() => {
     return Array.from(
       { length: getYearLimits.max - getYearLimits.min + 1 },
-      (_, i) => getYearLimits.min + i
+      (_, i) => getYearLimits.min + i,
     ).map((year) => ({
       value: year,
       label: year.toString(),
@@ -90,14 +97,16 @@ function ParentComponent() {
   const handleFilterClick = () => {
     setError(null);
     setData(null);
-    setTitle('');
+    setTitle("");
     setFilteredType(type);
     // Forçar limpeza completa do estado antes de fazer nova requisição
     setIsLoading(true);
 
     // Determina se é série histórica baseado no yearRange
     const isHistoricalRange = yearRange[0] !== yearRange[1];
-    const yearDisplay = isHistoricalRange ? `${yearRange[0]}-${yearRange[1]}` : yearRange[0];
+    const yearDisplay = isHistoricalRange
+      ? `${yearRange[0]}-${yearRange[1]}`
+      : yearRange[0];
     let locationName = "Piauí";
     if (city) {
       const selectedCity = municipios[city];
@@ -111,7 +120,9 @@ function ParentComponent() {
       filterInfo.push(`Território: ${Regioes[territory]}`);
     }
     if (faixaPopulacional) {
-      filterInfo.push(`Faixa Populacional: ${FaixaPopulacional[faixaPopulacional]}`);
+      filterInfo.push(
+        `Faixa Populacional: ${FaixaPopulacional[faixaPopulacional]}`,
+      );
     }
     if (aglomerado) {
       filterInfo.push(`Aglomerado: ${aglomerado}`);
@@ -120,29 +131,42 @@ function ParentComponent() {
       filterInfo.push(`Gerência: ${gerencia}`);
     }
     if (selectedFilters.length > 0) {
-      const filterNames = selectedFilters.map(filter => {
-        switch(filter.value) {
-          case 'etapa': return 'Etapa de Ensino';
-          case 'localidade': return 'Localidade';
-          case 'dependencia': return 'Dependência Administrativa';
-          case 'municipio': return 'Município';
-          default: return filter.value;
+      const filterNames = selectedFilters.map((filter) => {
+        switch (filter.value) {
+          case "etapa":
+            return "Etapa de Ensino";
+          case "localidade":
+            return "Localidade";
+          case "dependencia":
+            return "Dependência Administrativa";
+          case "municipio":
+            return "Município";
+          default:
+            return filter.value;
         }
       });
-      filterInfo.push(`Filtros: ${filterNames.join(', ')}`);
+      filterInfo.push(`Filtros: ${filterNames.join(", ")}`);
     }
 
     let fullTitle = `${titleMapping[type]} - ${locationName} (${yearDisplay})`;
     if (filterInfo.length > 0) {
-      fullTitle += ` | ${filterInfo.join(' | ')}`;
+      fullTitle += ` | ${filterInfo.join(" | ")}`;
     }
     setTitle(fullTitle);
 
     // Calcular valores dos filtros antes de atualizar estados
-    const isEtapaSelectedValue = selectedFilters.some(filter => filter.value === 'etapa');
-    const isLocalidadeSelectedValue = selectedFilters.some(filter => filter.value === 'localidade');
-    const isDependenciaSelectedValue = selectedFilters.some(filter => filter.value === 'dependencia');
-    const isMunicipioSelectedValue = selectedFilters.some(filter => filter.value === 'municipio');
+    const isEtapaSelectedValue = selectedFilters.some(
+      (filter) => filter.value === "etapa",
+    );
+    const isLocalidadeSelectedValue = selectedFilters.some(
+      (filter) => filter.value === "localidade",
+    );
+    const isDependenciaSelectedValue = selectedFilters.some(
+      (filter) => filter.value === "dependencia",
+    );
+    const isMunicipioSelectedValue = selectedFilters.some(
+      (filter) => filter.value === "municipio",
+    );
 
     setIsHistorical(isHistoricalRange);
     setDisplayHistorical(isHistoricalRange);
@@ -169,18 +193,21 @@ function ParentComponent() {
 
       // Usar os valores calculados diretamente, não os estados
       // Para evitar problema de estado assíncrono, usar refs para obter valores atualizados
-      const currentPageValue = shouldResetPage ? 1 : municipalityPageRef.current;
+      const currentPageValue = shouldResetPage
+        ? 1
+        : municipalityPageRef.current;
       const currentLimitValue = municipalityLimitRef.current;
 
       // Atualizar refs
       municipalityPageRef.current = currentPageValue;
       municipalityLimitRef.current = currentLimitValue;
 
-      const paginationParams = isMunicipioSelectedValue && !city
-        ? { page: currentPageValue, limit: currentLimitValue }
-        : {};
+      const paginationParams =
+        isMunicipioSelectedValue && !city
+          ? { page: currentPageValue, limit: currentLimitValue }
+          : {};
 
-      console.log('ParentComponent - Enviando dados para ApiComponent:', {
+      console.log("ParentComponent - Enviando dados para ApiComponent:", {
         isMunicipioSelected: isMunicipioSelectedValue,
         city,
         municipalityPage: paginationParams.page || municipalityPage,
@@ -194,7 +221,7 @@ function ParentComponent() {
         startYear: yearRange[0],
         endYear: yearRange[1],
         type,
-        filteredType
+        filteredType,
       });
 
       // Passar selectedFilters e type diretamente para garantir que os valores corretos sejam usados
@@ -209,7 +236,10 @@ function ParentComponent() {
         faixaPopulacional,
         aglomerado,
         gerencia,
-        citiesList: territory || faixaPopulacional || aglomerado || gerencia ? filteredCities : [],
+        citiesList:
+          territory || faixaPopulacional || aglomerado || gerencia
+            ? filteredCities
+            : [],
         // Adicionar paginação apenas quando municipality está selecionado e não há cidade específica
         ...paginationParams,
         // Passar selectedFilters para garantir que os valores corretos sejam usados
@@ -260,22 +290,22 @@ function ParentComponent() {
   const handleClearFilters = () => {
     setDisplayHistorical(false);
     setIsHistorical(false);
-    setType('enrollment');
-    setFilteredType('enrollment');
-    const limits = yearLimits['enrollment'];
+    setType("enrollment");
+    setFilteredType("enrollment");
+    const limits = yearLimits["enrollment"];
     setStartYear(limits.min);
     setEndYear(limits.max);
     setYear(limits.max);
     setFilteredYear(null);
     setYearRange([limits.min, limits.max]);
-    setCity('');
-    setTerritory('');
-    setFaixaPopulacional('');
-    setAglomerado('');
-    setGerencia('');
+    setCity("");
+    setTerritory("");
+    setFaixaPopulacional("");
+    setAglomerado("");
+    setGerencia("");
     setData(null);
     setError(null);
-    setTitle('');
+    setTitle("");
     setSelectedFilters([]);
     setIsEtapaSelected(false);
     setIsLocalidadeSelected(false);
@@ -283,24 +313,30 @@ function ParentComponent() {
     setIsMunicipioSelected(false);
 
     // Limpar também os filtros aplicados
-    setAppliedTerritory('');
-    setAppliedFaixaPopulacional('');
-    setAppliedAglomerado('');
-    setAppliedGerencia('');
+    setAppliedTerritory("");
+    setAppliedFaixaPopulacional("");
+    setAppliedAglomerado("");
+    setAppliedGerencia("");
     setAppliedSelectedFilters([]);
   };
 
   // Lógica de filtros dependentes - baseado nos filtros de localização
   const baseFilteredMunicipios = useMemo(() => {
     const territorioLabel = territory ? Regioes[territory] : null;
-    const faixaLabel = faixaPopulacional ? FaixaPopulacional[faixaPopulacional] : null;
+    const faixaLabel = faixaPopulacional
+      ? FaixaPopulacional[faixaPopulacional]
+      : null;
 
     return Object.values(municipios).filter((m) => {
-      if (territorioLabel && m.territorioDesenvolvimento !== territorioLabel) return false;
+      if (territorioLabel && m.territorioDesenvolvimento !== territorioLabel)
+        return false;
       if (faixaLabel && m.faixaPopulacional !== faixaLabel) return false;
-      if (aglomerado && String(m.aglomerado) !== String(aglomerado)) return false;
+      if (aglomerado && String(m.aglomerado) !== String(aglomerado))
+        return false;
       if (gerencia) {
-        const gerencias = String(m.gerencia).split(',').map((g) => g.trim());
+        const gerencias = String(m.gerencia)
+          .split(",")
+          .map((g) => g.trim());
         if (!gerencias.includes(String(gerencia))) return false;
       }
       return true;
@@ -314,36 +350,59 @@ function ParentComponent() {
   const filteredMunicipioOptions = useMemo(() => {
     return Object.entries(municipios)
       .filter(([, m]) => baseFilteredMunicipios.includes(m))
-      .map(([key, { nomeMunicipio }]) => ({ value: key, label: nomeMunicipio }));
+      .map(([key, { nomeMunicipio }]) => ({
+        value: key,
+        label: nomeMunicipio,
+      }));
   }, [baseFilteredMunicipios]);
 
   const filteredTerritorioOptions = useMemo(() => {
-    const uniqueLabels = [...new Set(baseFilteredMunicipios.map((m) => m.territorioDesenvolvimento).filter(Boolean))];
+    const uniqueLabels = [
+      ...new Set(
+        baseFilteredMunicipios
+          .map((m) => m.territorioDesenvolvimento)
+          .filter(Boolean),
+      ),
+    ];
     return Object.entries(Regioes)
       .filter(([, label]) => uniqueLabels.includes(label))
       .map(([id, label]) => ({ value: id, label }));
   }, [baseFilteredMunicipios]);
 
   const filteredFaixaPopulacionalOptions = useMemo(() => {
-    const uniqueLabels = [...new Set(baseFilteredMunicipios.map((m) => m.faixaPopulacional).filter(Boolean))];
+    const uniqueLabels = [
+      ...new Set(
+        baseFilteredMunicipios.map((m) => m.faixaPopulacional).filter(Boolean),
+      ),
+    ];
     return Object.entries(FaixaPopulacional)
       .filter(([, label]) => uniqueLabels.includes(label))
       .map(([id, label]) => ({ value: id, label }));
   }, [baseFilteredMunicipios]);
 
   const filteredAglomeradoOptions = useMemo(() => {
-    return [...new Set(baseFilteredMunicipios.map((m) => m.aglomerado).filter((a) => a && a !== 'undefined'))]
+    return [
+      ...new Set(
+        baseFilteredMunicipios
+          .map((m) => m.aglomerado)
+          .filter((a) => a && a !== "undefined"),
+      ),
+    ]
       .sort((a, b) => Number(a) - Number(b))
       .map((a) => ({ value: a, label: `AG ${a}` }));
   }, [baseFilteredMunicipios]);
 
   const filteredGerenciaOptions = useMemo(() => {
-    return [...new Set(
-      baseFilteredMunicipios
-        .map((m) => m.gerencia)
-        .filter((g) => g && g !== 'undefined')
-        .flatMap((g) => (g.includes(',') ? g.split(',').map((x) => x.trim()) : [g]))
-    )]
+    return [
+      ...new Set(
+        baseFilteredMunicipios
+          .map((m) => m.gerencia)
+          .filter((g) => g && g !== "undefined")
+          .flatMap((g) =>
+            g.includes(",") ? g.split(",").map((x) => x.trim()) : [g],
+          ),
+      ),
+    ]
       .sort((a, b) => Number(a) - Number(b))
       .map((g) => ({ value: g, label: `${g}ª GRE` }));
   }, [baseFilteredMunicipios]);
@@ -354,7 +413,7 @@ function ParentComponent() {
       if (value && options.length > 0) {
         const exists = options.some((opt) => opt.value === value);
         if (!exists) {
-          setter('');
+          setter("");
         }
       }
     }, [value, setter, options]);
@@ -363,44 +422,66 @@ function ParentComponent() {
   // Aplicar limpeza de filtros inválidos
   useClearInvalidFilter(city, setCity, filteredMunicipioOptions);
   useClearInvalidFilter(territory, setTerritory, filteredTerritorioOptions);
-  useClearInvalidFilter(faixaPopulacional, setFaixaPopulacional, filteredFaixaPopulacionalOptions);
+  useClearInvalidFilter(
+    faixaPopulacional,
+    setFaixaPopulacional,
+    filteredFaixaPopulacionalOptions,
+  );
   useClearInvalidFilter(aglomerado, setAglomerado, filteredAglomeradoOptions);
   useClearInvalidFilter(gerencia, setGerencia, filteredGerenciaOptions);
 
   // Limpar filtros de localização quando um município específico é selecionado
   useEffect(() => {
     if (city) {
-      setTerritory('');
-      setFaixaPopulacional('');
-      setAglomerado('');
-      setGerencia('');
+      setTerritory("");
+      setFaixaPopulacional("");
+      setAglomerado("");
+      setGerencia("");
     }
   }, [city]);
 
-  const filteredCities = Object.entries(municipios).filter(([, {
-    territorioDesenvolvimento,
-    faixaPopulacional: cityFaixaPopulacional,
-    aglomerado: cityAglomerado,
-    gerencia: cityGerencia
-  }]) => {
-    const matchesTerritory = !territory || territorioDesenvolvimento === Regioes[territory];
-    const matchesFaixaPopulacional = !faixaPopulacional || cityFaixaPopulacional === FaixaPopulacional[faixaPopulacional];
-    const matchesAglomerado = !aglomerado || cityAglomerado === aglomerado;
+  const filteredCities = Object.entries(municipios).filter(
+    ([
+      ,
+      {
+        territorioDesenvolvimento,
+        faixaPopulacional: cityFaixaPopulacional,
+        aglomerado: cityAglomerado,
+        gerencia: cityGerencia,
+      },
+    ]) => {
+      const matchesTerritory =
+        !territory || territorioDesenvolvimento === Regioes[territory];
+      const matchesFaixaPopulacional =
+        !faixaPopulacional ||
+        cityFaixaPopulacional === FaixaPopulacional[faixaPopulacional];
+      const matchesAglomerado = !aglomerado || cityAglomerado === aglomerado;
 
-    // Para gerência, verificar se a gerencia selecionada está contida na string de gerencias da cidade
-    // (considerando que uma cidade pode ter múltiplas gerencias separadas por vírgula)
-    const matchesGerencia = !gerencia || cityGerencia.split(',').map(g => g.trim()).includes(gerencia);
+      // Para gerência, verificar se a gerencia selecionada está contida na string de gerencias da cidade
+      // (considerando que uma cidade pode ter múltiplas gerencias separadas por vírgula)
+      const matchesGerencia =
+        !gerencia ||
+        cityGerencia
+          .split(",")
+          .map((g) => g.trim())
+          .includes(gerencia);
 
-    // Retorna true apenas se TODAS as condições selecionadas são atendidas
-    return matchesTerritory && matchesFaixaPopulacional && matchesAglomerado && matchesGerencia;
-  });
+      // Retorna true apenas se TODAS as condições selecionadas são atendidas
+      return (
+        matchesTerritory &&
+        matchesFaixaPopulacional &&
+        matchesAglomerado &&
+        matchesGerencia
+      );
+    },
+  );
 
   const titleMapping = {
     enrollment: "Número de matrículas",
     "school/count": "Número de escolas",
     class: "Número de turmas",
     teacher: "Número de docentes",
-    employees: "Número de funcionários"
+    employees: "Número de funcionários",
   };
 
   const typeOptions = Object.entries(titleMapping).map(([key, label]) => ({
@@ -413,23 +494,45 @@ function ParentComponent() {
     label: value,
   }));
 
-  const faixaPopulacionalOptions = Object.entries(FaixaPopulacional).map(([key, value]) => ({
-    value: key,
-    label: value,
-  }));
+  const faixaPopulacionalOptions = Object.entries(FaixaPopulacional).map(
+    ([key, value]) => ({
+      value: key,
+      label: value,
+    }),
+  );
 
-  const gerenciaOptions = [...new Set(Object.values(municipios).flatMap(m => String(m.gerencia).split(',').map(g => g.trim())).filter(Boolean))]
+  const gerenciaOptions = [
+    ...new Set(
+      Object.values(municipios)
+        .flatMap((m) =>
+          String(m.gerencia)
+            .split(",")
+            .map((g) => g.trim()),
+        )
+        .filter(Boolean),
+    ),
+  ]
     .sort((a, b) => parseInt(a) - parseInt(b))
-    .map(gerencia => ({
+    .map((gerencia) => ({
       value: gerencia,
-      label: gerencia + 'ª GRE',
+      label: gerencia + "ª GRE",
     }));
 
-  const aglomeradoOptions = [...new Set(Object.values(municipios).flatMap(m => String(m.aglomerado).split(',').map(a => a.trim())).filter(Boolean))]
+  const aglomeradoOptions = [
+    ...new Set(
+      Object.values(municipios)
+        .flatMap((m) =>
+          String(m.aglomerado)
+            .split(",")
+            .map((a) => a.trim()),
+        )
+        .filter(Boolean),
+    ),
+  ]
     .sort((a, b) => parseInt(a) - parseInt(b))
-    .map(aglomerado => ({
+    .map((aglomerado) => ({
       value: aglomerado,
-      label: 'AG ' + aglomerado,
+      label: "AG " + aglomerado,
     }));
 
   const cityOptions = filteredCities.map(([key, { nomeMunicipio }]) => ({
@@ -438,10 +541,10 @@ function ParentComponent() {
   }));
 
   const filterOptions = [
-    { value: 'localidade', label: 'Localidade' },
-    ...(type !== 'employees' ? [{ value: 'etapa', label: 'Etapa' }] : []),
-    { value: 'dependencia', label: 'Dependência Administrativa' },
-    { value: 'municipio', label: 'Município' },
+    { value: "localidade", label: "Localidade" },
+    ...(type !== "employees" ? [{ value: "etapa", label: "Etapa" }] : []),
+    { value: "dependencia", label: "Dependência Administrativa" },
+    { value: "municipio", label: "Município" },
   ];
 
   const theme = useTheme();
@@ -449,166 +552,220 @@ function ParentComponent() {
   return (
     <div className="app-container">
       <div className="flex flex-col gap-4 p-0 m-0">
+        {/* Tipo + Filtros Múltiplos + Botão Mais Filtros - Primeira linha */}
+        <div className="md:col-span-3">
+          <div className="flex flex-col lg:flex-row items-end gap-4">
+            <div className="w-full lg:flex-1">
+              <label
+                htmlFor="typeSelect"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Tipo:
+              </label>
+              <Select
+                id="typeSelect"
+                value={typeOptions.find((option) => option.value === type)}
+                onChange={(selectedOption) => {
+                  setType(selectedOption.value);
+                  setSelectedFilters([]);
+                }}
+                options={typeOptions}
+                placeholder="Selecione o tipo"
+                size="xs"
+              />
+            </div>
 
-          {/* Tipo + Filtros Múltiplos + Botão Mais Filtros - Primeira linha */}
+            <div className="w-full lg:flex-1">
+              <label
+                htmlFor="multiFilterSelect"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Filtros:
+              </label>
+              <Select
+                id="multiFilterSelect"
+                value={selectedFilters}
+                onChange={(newValue, actionMeta) => {
+                  const isHistoricalRange = yearRange[0] !== yearRange[1];
+                  if (isHistoricalRange) {
+                    setSelectedFilters(newValue.slice(-1));
+                  } else if (newValue.length <= 2) {
+                    setSelectedFilters(newValue);
+                  } else {
+                    setSelectedFilters(newValue.slice(-2));
+                  }
+                }}
+                options={filterOptions}
+                isMulti
+                placeholder={
+                  yearRange[0] !== yearRange[1]
+                    ? "Selecione 1 filtro"
+                    : "Selecione até 2 filtros"
+                }
+                size="xs"
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Filtros recolhíveis */}
+        <div className="md:col-span-3">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {/* Território */}
+            <div className="md:col-span-1">
+              <Select
+                id="territorySelect"
+                value={
+                  filteredTerritorioOptions.find(
+                    (option) => option.value === territory,
+                  ) || null
+                }
+                onChange={(selectedOption) => {
+                  setTerritory(selectedOption ? selectedOption.value : "");
+                  setCity("");
+                }}
+                options={filteredTerritorioOptions}
+                placeholder="Território de Desenvolvimento"
+                size="xs"
+                isClearable={true}
+                disabled={otherLocalityDisabled}
+              />
+            </div>
+
+            {/* Faixa Populacional */}
+            <div className="md:col-span-1">
+              <Select
+                id="faixaPopulacionalSelect"
+                value={
+                  filteredFaixaPopulacionalOptions.find(
+                    (option) => option.value === faixaPopulacional,
+                  ) || null
+                }
+                onChange={(selectedOption) => {
+                  setFaixaPopulacional(
+                    selectedOption ? selectedOption.value : "",
+                  );
+                  setCity("");
+                }}
+                options={filteredFaixaPopulacionalOptions}
+                placeholder="Faixa Populacional"
+                size="xs"
+                isClearable={true}
+                disabled={otherLocalityDisabled}
+              />
+            </div>
+
+            {/* Aglomerado */}
+            <div className="md:col-span-1">
+              <Select
+                id="aglomeradoSelect"
+                value={
+                  filteredAglomeradoOptions.find(
+                    (option) => option.value === aglomerado,
+                  ) || null
+                }
+                onChange={(selectedOption) =>
+                  setAglomerado(selectedOption ? selectedOption.value : "")
+                }
+                options={filteredAglomeradoOptions}
+                placeholder="Aglomerado - AG"
+                size="xs"
+                isClearable={true}
+                disabled={otherLocalityDisabled}
+              />
+            </div>
+
+            {/* Gerência */}
+            <div className="md:col-span-1">
+              <Select
+                id="gerenciaSelect"
+                value={
+                  filteredGerenciaOptions.find(
+                    (option) => option.value === gerencia,
+                  ) || null
+                }
+                onChange={(selectedOption) =>
+                  setGerencia(selectedOption ? selectedOption.value : "")
+                }
+                options={filteredGerenciaOptions}
+                placeholder="Gerência Regional de Ensino - GRE"
+                size="xs"
+                isClearable={true}
+                disabled={otherLocalityDisabled}
+              />
+            </div>
+
+            {/* Cidade */}
+            <div className="md:col-span-1">
+              <Select
+                id="citySelect"
+                value={
+                  filteredMunicipioOptions.find(
+                    (option) => option.value === city,
+                  ) || null
+                }
+                onChange={(selectedOption) =>
+                  setCity(selectedOption ? selectedOption.value : "")
+                }
+                options={filteredMunicipioOptions}
+                placeholder="Município"
+                size="xs"
+                isClearable={true}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Período - Todas as colunas, terceira linha */}
+        <div className="md:col-span-3">
+          {/* Período - Seleção de Anos (Substituindo o Slider) */}
           <div className="md:col-span-3">
-            <div className="flex flex-col lg:flex-row items-end gap-4">
-              <div className="w-full lg:flex-1">
-                <label htmlFor="typeSelect" className="block text-sm font-medium text-gray-700 mb-1">Tipo:</label>
+            <div className="flex flex-col sm:flex-row gap-4 py-4">
+              <div className="flex-1">
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  De:
+                </label>
                 <Select
-                  id="typeSelect"
-                  value={typeOptions.find(option => option.value === type)}
-                  onChange={(selectedOption) => {
-                    setType(selectedOption.value);
-                    setSelectedFilters([]);
-                  }}
-                  options={typeOptions}
-                  placeholder="Selecione o tipo"
+                  id="startYearSelect"
+                  options={yearOptions}
+                  value={yearOptions.find((opt) => opt.value === yearRange[0])}
+                  onChange={(selected) =>
+                    setYearRange([selected.value, yearRange[1]])
+                  }
                   size="xs"
                 />
               </div>
 
-              <div className="w-full lg:flex-1">
-                <label htmlFor="multiFilterSelect" className="block text-sm font-medium text-gray-700 mb-1">Filtros:</label>
+              <div className="flex-1">
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Até:
+                </label>
                 <Select
-                  id="multiFilterSelect"
-                  value={selectedFilters}
-                  onChange={(newValue, actionMeta) => {
-                    const isHistoricalRange = yearRange[0] !== yearRange[1];
-                    if (isHistoricalRange) {
-                      setSelectedFilters(newValue.slice(-1));
-                    } else if (newValue.length <= 2) {
-                      setSelectedFilters(newValue);
-                    } else {
-                      setSelectedFilters(newValue.slice(-2));
-                    }
-                  }}
-                  options={filterOptions}
-                  isMulti
-                  placeholder={yearRange[0] !== yearRange[1] ? "Selecione 1 filtro" : "Selecione até 2 filtros"}
+                  id="endYearSelect"
+                  options={yearOptions}
+                  value={yearOptions.find((opt) => opt.value === yearRange[1])}
+                  onChange={(selected) =>
+                    setYearRange([yearRange[0], selected.value])
+                  }
                   size="xs"
                 />
               </div>
-
-              {/* Botão de toggle para filtros adicionais */}
-              <div className="w-full lg:w-auto">
-                <Button
-                  variant="outlined"
-                  size="small"
-                  startIcon={filtersExpanded ? <ExpandLess /> : <ExpandMore />}
-                  onClick={() => setFiltersExpanded(!filtersExpanded)}
-                  sx={{
-                    minWidth: 'auto',
-                    padding: '8px 16px',
-                    whiteSpace: 'nowrap',
-                    height: 'fit-content',
-                    mb: 0.5,
-                    width: { xs: '100%', lg: 'auto' }
-                  }}
-                >
-                  {filtersExpanded ? 'Menos Filtros' : 'Mais Filtros'}
-                </Button>
-              </div>
             </div>
           </div>
+        </div>
 
-          {/* Filtros recolhíveis */}
-          <Collapse in={filtersExpanded} timeout="auto" unmountOnExit>
-            <div className="md:col-span-3">
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                {/* Território */}
-                <div className="md:col-span-1">
-                  <Select
-                    id="territorySelect"
-                    value={filteredTerritorioOptions.find(option => option.value === territory) || null}
-                    onChange={(selectedOption) => {
-                      setTerritory(selectedOption ? selectedOption.value : '');
-                      setCity('');
-                    }}
-                    options={filteredTerritorioOptions}
-                    placeholder="Território de Desenvolvimento"
-                    size="xs"
-                    isClearable={true}
-                    disabled={otherLocalityDisabled}
-                  />
-                </div>
-
-                {/* Faixa Populacional */}
-                <div className="md:col-span-1">
-                  <Select
-                    id="faixaPopulacionalSelect"
-                    value={filteredFaixaPopulacionalOptions.find(option => option.value === faixaPopulacional) || null}
-                    onChange={(selectedOption) => {
-                      setFaixaPopulacional(selectedOption ? selectedOption.value : '');
-                      setCity('');
-                    }}
-                    options={filteredFaixaPopulacionalOptions}
-                    placeholder="Faixa Populacional"
-                    size="xs"
-                    isClearable={true}
-                    disabled={otherLocalityDisabled}
-                  />
-                </div>
-
-                {/* Aglomerado */}
-                <div className="md:col-span-1">
-                  <Select
-                    id="aglomeradoSelect"
-                    value={filteredAglomeradoOptions.find(option => option.value === aglomerado) || null}
-                    onChange={(selectedOption) => setAglomerado(selectedOption ? selectedOption.value : '')}
-                    options={filteredAglomeradoOptions}
-                    placeholder="Aglomerado - AG"
-                    size="xs"
-                    isClearable={true}
-                    disabled={otherLocalityDisabled}
-                  />
-                </div>
-
-                {/* Gerência */}
-                <div className="md:col-span-1">
-                  <Select
-                    id="gerenciaSelect"
-                    value={filteredGerenciaOptions.find(option => option.value === gerencia) || null}
-                    onChange={(selectedOption) => setGerencia(selectedOption ? selectedOption.value : '')}
-                    options={filteredGerenciaOptions}
-                    placeholder="Gerência Regional de Ensino - GRE"
-                    size="xs"
-                    isClearable={true}
-                    disabled={otherLocalityDisabled}
-                  />
-                </div>
-
-                {/* Cidade */}
-                <div className="md:col-span-1">
-                  <Select
-                    id="citySelect"
-                    value={filteredMunicipioOptions.find(option => option.value === city) || null}
-                    onChange={(selectedOption) => setCity(selectedOption ? selectedOption.value : '')}
-                    options={filteredMunicipioOptions}
-                    placeholder="Município"
-                    size="xs"
-                    isClearable={true}
-                  />
-                </div>
-              </div>
-            </div>
-          </Collapse>
-
-          {/* Período - Todas as colunas, terceira linha */}
-          <div className="md:col-span-3">
-            <YearRangeSlider
-              minYear={getYearLimits.min}
-              maxYear={getYearLimits.max}
-              value={yearRange}
-              onChange={setYearRange}
-            />
-          </div>
-
-          {/* Botões - Ocupa todo o espaço da linha */}
-          <div className="md:col-span-3 flex flex-col justify-end">
-            <div className="flex flex-col sm:flex-row gap-3 justify-end items-end">
-              {/* Toggle para modo consolidado (apenas quando há filtros territoriais combinados com outros filtros aplicados na última busca) */}
-              {(appliedTerritory || appliedFaixaPopulacional || appliedAglomerado || appliedGerencia) && (isEtapaSelected || isLocalidadeSelected || isDependenciaSelected) && !isMunicipioSelected && (
+        {/* Botões - Ocupa todo o espaço da linha */}
+        <div className="md:col-span-3 flex flex-col justify-end">
+          <div className="flex flex-col sm:flex-row gap-3 justify-end items-end">
+            {/* Toggle para modo consolidado (apenas quando há filtros territoriais combinados com outros filtros aplicados na última busca) */}
+            {(appliedTerritory ||
+              appliedFaixaPopulacional ||
+              appliedAglomerado ||
+              appliedGerencia) &&
+              (isEtapaSelected ||
+                isLocalidadeSelected ||
+                isDependenciaSelected) &&
+              !isMunicipioSelected && (
                 <div className="flex items-center space-x-2">
                   <label className="flex items-center pb-2 space-x-2 cursor-pointer">
                     <Switch
@@ -617,28 +774,34 @@ function ParentComponent() {
                       color="primary"
                       size="small"
                       sx={{
-                        '& .MuiSwitch-thumb': {
-                          backgroundColor: showConsolidated ? '#1976d2' : '#fafafa',
+                        "& .MuiSwitch-thumb": {
+                          backgroundColor: showConsolidated
+                            ? "#1976d2"
+                            : "#fafafa",
                         },
-                        '& .MuiSwitch-track': {
-                          backgroundColor: showConsolidated ? '#1976d2' : '#ccc',
+                        "& .MuiSwitch-track": {
+                          backgroundColor: showConsolidated
+                            ? "#1976d2"
+                            : "#ccc",
                         },
                       }}
                     />
-                    <span className="text-gray-700">Mostrar dados consolidados</span>
+                    <span className="text-gray-700">
+                      Mostrar dados consolidados
+                    </span>
                   </label>
                 </div>
               )}
-              <Button
-                variant="contained"
-                color="primary"
-                onClick={handleFilterClick}
-                className="w-full sm:w-auto"
-              >
-                Mostrar resultados
-              </Button>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleFilterClick}
+              className="w-full sm:w-auto"
+            >
+              Mostrar resultados
+            </Button>
 
-              {/* <Button
+            {/* <Button
                 variant="contained"
                 color="success"
                 onClick={handleExportTable}
@@ -650,25 +813,22 @@ function ParentComponent() {
                 Exportar Tabelão
               </Button> */}
 
-              <Button
-                style={{
-                  backgroundColor: '#f0f0f0',
-                  color: '#000',
-                }}
-                variant="contained"
-                onClick={handleClearFilters}
-                className="w-full sm:w-auto"
-              >
-                Limpar
-              </Button>
-            </div>
+            <Button
+              style={{
+                backgroundColor: "#f0f0f0",
+                color: "#000",
+              }}
+              variant="contained"
+              onClick={handleClearFilters}
+              className="w-full sm:w-auto"
+            >
+              Limpar
+            </Button>
           </div>
         </div>
+      </div>
 
-
-       {isLoading && (
-        <Loading />
-      )}
+      {isLoading && <Loading />}
       {error && (
         <div className="error-message">
           <p>{error}</p>
@@ -681,15 +841,16 @@ function ParentComponent() {
         <Typography
           variant="body1"
           sx={{
-            textAlign: 'center',
-            fontSize: '18px',
-            fontWeight: 'bold',
-            margin: '20px auto',
-            maxWidth: '400px',
-            color: theme.palette.primary.main
+            textAlign: "center",
+            fontSize: "18px",
+            fontWeight: "bold",
+            margin: "20px auto",
+            maxWidth: "400px",
+            color: theme.palette.primary.main,
           }}
         >
-          Selecione os filtros desejados e clique em "Filtrar" para montar uma consulta.
+          Selecione os filtros desejados e clique em "Filtrar" para montar uma
+          consulta.
         </Typography>
       )}
 
@@ -717,7 +878,9 @@ function ParentComponent() {
       {!isLoading && !error && data && title ? (
         <ApiDataTable
           data={data.finalResult ? data.finalResult : data}
-          municipioData={data.allResults && data.allResults.length > 0 ? data.allResults : []}
+          municipioData={
+            data.allResults && data.allResults.length > 0 ? data.allResults : []
+          }
           isEtapaSelected={isEtapaSelected}
           isLocalidadeSelected={isLocalidadeSelected}
           isDependenciaSelected={isDependenciaSelected}
@@ -742,15 +905,19 @@ function ParentComponent() {
             setMunicipalityPage(1);
             handleFilterClick();
           }}
-          fetchAllDataConfig={isMunicipioSelected ? {
-            type: filteredType,
-            year: filteredYear || year,
-            isHistorical,
-            startYear,
-            endYear,
-            city,
-            selectedFilters
-          } : null}
+          fetchAllDataConfig={
+            isMunicipioSelected
+              ? {
+                  type: filteredType,
+                  year: filteredYear || year,
+                  isHistorical,
+                  startYear,
+                  endYear,
+                  city,
+                  selectedFilters,
+                }
+              : null
+          }
         />
       ) : null}
     </div>

--- a/src/components/pages/education/financial/state/StateFilters.jsx
+++ b/src/components/pages/education/financial/state/StateFilters.jsx
@@ -1,23 +1,23 @@
-import React from 'react';
-import { Button } from '@mui/material';
-import TableTypeFilter from '../../../../helpers/TableTypeFilter.jsx';
-import YearRangeFilter from '../../../../helpers/YearRangeFilter.jsx';
-import { stateTableNames } from '../../../../../services/csvService.jsx';
+import React from "react";
+import { Button } from "@mui/material";
+import TableTypeFilter from "../../../../helpers/TableTypeFilter.jsx";
+import YearRangeFilter from "../../../../helpers/YearRangeFilter.jsx";
+import { stateTableNames } from "../../../../../services/csvService.jsx";
 
-const StateFilters = ({ 
-  selectedTable, 
-  onTableChange, 
-  startYear, 
-  endYear, 
-  onStartYearChange, 
+const StateFilters = ({
+  selectedTable,
+  onTableChange,
+  startYear,
+  endYear,
+  onStartYearChange,
   onEndYearChange,
   onFilter,
-  loading = false
+  loading = false,
 }) => {
   // Opções das tabelas do estado
   const tableOptions = Object.entries(stateTableNames).map(([key, label]) => ({
     value: key,
-    label: label
+    label: label,
   }));
 
   return (

--- a/src/components/pages/education/higher/FilterComponent.jsx
+++ b/src/components/pages/education/higher/FilterComponent.jsx
@@ -1,37 +1,48 @@
-import { ExpandLess, ExpandMore } from '@mui/icons-material';
-import { Button, Collapse, Switch, Typography } from '@mui/material';
-import { useTheme } from '@mui/material/styles';
-import React, { useEffect, useMemo, useState } from 'react';
+import { ExpandLess, ExpandMore } from "@mui/icons-material";
+import { Button, Collapse, Switch, Typography } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
+import React, { useEffect, useMemo, useState } from "react";
 // import { exportHigherEducationTable } from '../../../../services/exportTableService.jsx';
-import '../../../../style/RevenueTableContainer.css';
-import '../../../../style/TableFilters.css';
-import { FaixaPopulacional, municipios, Regioes } from '../../../../utils/citiesMapping';
-import { Loading, Select } from '../../../ui';
-import YearRangeSlider from '../../../ui/YearRangeSlider';
-import ApiHigherContainer from './ApiHigherComponent.jsx';
-import DataTable from './DataTable.jsx';
+import "../../../../style/RevenueTableContainer.css";
+import "../../../../style/TableFilters.css";
+import {
+  FaixaPopulacional,
+  municipios,
+  Regioes,
+} from "../../../../utils/citiesMapping";
+import { Loading, Select } from "../../../ui";
+import YearRangeSlider from "../../../ui/YearRangeSlider";
+import ApiHigherContainer from "./ApiHigherComponent.jsx";
+import DataTable from "./DataTable.jsx";
 
 function FilterComponent() {
-  const [type, setType] = useState('university/count');
+  const [type, setType] = useState("university/count");
   const [isHistorical, setIsHistorical] = useState(false);
-  const [city, setCity] = useState('');
-  const [territory, setTerritory] = useState('');
-  const [faixaPopulacional, setFaixaPopulacional] = useState('');
-  const [aglomerado, setAglomerado] = useState('');
-  const [gerencia, setGerencia] = useState('');
+  const [city, setCity] = useState("");
+  const [territory, setTerritory] = useState("");
+  const [faixaPopulacional, setFaixaPopulacional] = useState("");
+  const [aglomerado, setAglomerado] = useState("");
+  const [gerencia, setGerencia] = useState("");
   const [data, setData] = useState(null);
   const [error, setError] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [title, setTitle] = useState('');
+  const [title, setTitle] = useState("");
   const [selectedFilters, setSelectedFilters] = useState([]);
   const [displayHistorical, setDisplayHistorical] = useState(false);
   const [isModalidadeSelected, setIsModalidadeSelected] = useState(false);
   const [isRegimeSelected, setIsRegimeSelected] = useState(false);
-  const [isFormacaoDocenteSelected, setIsFormacaoDocenteSelected] = useState(false);
-  const [isCategoriaAdministrativaSelected, setIsCategoriaAdministrativaSelected] = useState(false);
-  const [isFaixaEtariaSuperiorSelected, setIsFaixaEtariaSuperiorSelected] = useState(false);
-  const [isOrganizacaoAcademicaSelected, setIsOrganizacaoAcademicaSelected] = useState(false);
-  const [isInstituicaoEnsinoSelected, setIsInstituicaoEnsinoSelected] = useState(false);
+  const [isFormacaoDocenteSelected, setIsFormacaoDocenteSelected] =
+    useState(false);
+  const [
+    isCategoriaAdministrativaSelected,
+    setIsCategoriaAdministrativaSelected,
+  ] = useState(false);
+  const [isFaixaEtariaSuperiorSelected, setIsFaixaEtariaSuperiorSelected] =
+    useState(false);
+  const [isOrganizacaoAcademicaSelected, setIsOrganizacaoAcademicaSelected] =
+    useState(false);
+  const [isInstituicaoEnsinoSelected, setIsInstituicaoEnsinoSelected] =
+    useState(false);
   const [isMunicipioSelected, setIsMunicipioSelected] = useState(false);
   const [showConsolidated, setShowConsolidated] = useState(false);
 
@@ -47,19 +58,21 @@ function FilterComponent() {
   const [yearRange, setYearRange] = useState([2020, 2023]);
 
   // Estados para armazenar os filtros aplicados na última busca
-  const [appliedTerritory, setAppliedTerritory] = useState('');
-  const [appliedFaixaPopulacional, setAppliedFaixaPopulacional] = useState('');
-  const [appliedAglomerado, setAppliedAglomerado] = useState('');
-  const [appliedGerencia, setAppliedGerencia] = useState('');
+  const [appliedTerritory, setAppliedTerritory] = useState("");
+  const [appliedFaixaPopulacional, setAppliedFaixaPopulacional] = useState("");
+  const [appliedAglomerado, setAppliedAglomerado] = useState("");
+  const [appliedGerencia, setAppliedGerencia] = useState("");
   const [appliedSelectedFilters, setAppliedSelectedFilters] = useState([]);
 
-
-  const yearLimits = useMemo(() => ({
-    'university/count': { min: 2020, max: 2023 },
-    'university_enrollment': { min: 2020, max: 2023 },
-    'university_teacher': { min: 2020, max: 2023 },
-    'course_count': { min: 2020, max: 2023 }
-  }), []);
+  const yearLimits = useMemo(
+    () => ({
+      "university/count": { min: 2020, max: 2023 },
+      university_enrollment: { min: 2020, max: 2023 },
+      university_teacher: { min: 2020, max: 2023 },
+      course_count: { min: 2020, max: 2023 },
+    }),
+    [],
+  );
 
   const getYearLimits = useMemo(() => {
     return yearLimits[type] || { min: 2000, max: 2023 };
@@ -68,16 +81,18 @@ function FilterComponent() {
   const yearOptions = useMemo(() => {
     return Array.from(
       { length: getYearLimits.max - getYearLimits.min + 1 },
-      (_, i) => getYearLimits.min + i
+      (_, i) => getYearLimits.min + i,
     ).map((year) => ({
       value: year,
       label: year.toString(),
     }));
   }, [getYearLimits]);
 
-  const [startYear, setStartYear] = useState(yearLimits['university/count'].min);
-  const [endYear, setEndYear] = useState(yearLimits['university/count'].max);
-  const [year, setYear] = useState(yearLimits['university/count'].max);
+  const [startYear, setStartYear] = useState(
+    yearLimits["university/count"].min,
+  );
+  const [endYear, setEndYear] = useState(yearLimits["university/count"].max);
+  const [year, setYear] = useState(yearLimits["university/count"].max);
 
   useEffect(() => {
     setYear(getYearLimits.max);
@@ -90,7 +105,7 @@ function FilterComponent() {
     setIsLoading(true);
     setError(null);
     setData(null);
-    setTitle('');
+    setTitle("");
 
     // Resetar paginação quando filtros mudarem
     setPaginationPage(1);
@@ -98,7 +113,9 @@ function FilterComponent() {
 
     // Determina se é série histórica baseado no yearRange
     const isHistoricalRange = yearRange[0] !== yearRange[1];
-    const yearDisplay = isHistoricalRange ? `${yearRange[0]}-${yearRange[1]}` : yearRange[0];
+    const yearDisplay = isHistoricalRange
+      ? `${yearRange[0]}-${yearRange[1]}`
+      : yearRange[0];
 
     setIsHistorical(isHistoricalRange);
     setDisplayHistorical(isHistoricalRange);
@@ -120,7 +137,9 @@ function FilterComponent() {
 
     // Adicionar faixa populacional se selecionada
     if (faixaPopulacional) {
-      filterInfo.push(`Faixa Populacional: ${FaixaPopulacional[faixaPopulacional]}`);
+      filterInfo.push(
+        `Faixa Populacional: ${FaixaPopulacional[faixaPopulacional]}`,
+      );
     }
 
     // Adicionar aglomerado se selecionado
@@ -134,38 +153,65 @@ function FilterComponent() {
     }
 
     if (selectedFilters.length > 0) {
-      const filterNames = selectedFilters.map(filter => {
-        switch(filter.value) {
-          case 'modalidade': return 'Modalidade';
-          case 'regimeDeTrabalho': return 'Regime de Trabalho';
-          case 'formacaoDocente': return 'Formação Docente';
-          case 'categoriaAdministrativa': return 'Categoria Administrativa';
-          case 'faixaEtariaSuperior': return 'Faixa Etária';
-          case 'organizacaoAcademica': return 'Organização Acadêmica';
-          case 'instituicaoEnsino': return 'Instituição de Ensino';
-          case 'municipio': return 'Município';
-          default: return filter.value;
+      const filterNames = selectedFilters.map((filter) => {
+        switch (filter.value) {
+          case "modalidade":
+            return "Modalidade";
+          case "regimeDeTrabalho":
+            return "Regime de Trabalho";
+          case "formacaoDocente":
+            return "Formação Docente";
+          case "categoriaAdministrativa":
+            return "Categoria Administrativa";
+          case "faixaEtariaSuperior":
+            return "Faixa Etária";
+          case "organizacaoAcademica":
+            return "Organização Acadêmica";
+          case "instituicaoEnsino":
+            return "Instituição de Ensino";
+          case "municipio":
+            return "Município";
+          default:
+            return filter.value;
         }
       });
-      filterInfo.push(`Filtros: ${filterNames.join(', ')}`);
+      filterInfo.push(`Filtros: ${filterNames.join(", ")}`);
     }
 
     let fullTitle = `${titleMapping[type]} - ${locationName} (${yearDisplay})`;
 
     if (filterInfo.length > 0) {
-      fullTitle += ` | ${filterInfo.join(' | ')}`;
+      fullTitle += ` | ${filterInfo.join(" | ")}`;
     }
 
-    setTitle(type ? fullTitle : '');
+    setTitle(type ? fullTitle : "");
 
-    setIsModalidadeSelected(selectedFilters.some(filter => filter.value === 'modalidade'));
-    setIsRegimeSelected(selectedFilters.some(filter => filter.value === 'regimeDeTrabalho'));
-    setIsFormacaoDocenteSelected(selectedFilters.some(filter => filter.value === 'formacaoDocente'));
-    setIsCategoriaAdministrativaSelected(selectedFilters.some(filter => filter.value === 'categoriaAdministrativa'));
-    setIsFaixaEtariaSuperiorSelected(selectedFilters.some(filter => filter.value === 'faixaEtariaSuperior'));
-    setIsOrganizacaoAcademicaSelected(selectedFilters.some(filter => filter.value === 'organizacaoAcademica'));
-    setIsInstituicaoEnsinoSelected(selectedFilters.some(filter => filter.value === 'instituicaoEnsino'));
-    setIsMunicipioSelected(selectedFilters.some(filter => filter.value === 'municipio'));
+    setIsModalidadeSelected(
+      selectedFilters.some((filter) => filter.value === "modalidade"),
+    );
+    setIsRegimeSelected(
+      selectedFilters.some((filter) => filter.value === "regimeDeTrabalho"),
+    );
+    setIsFormacaoDocenteSelected(
+      selectedFilters.some((filter) => filter.value === "formacaoDocente"),
+    );
+    setIsCategoriaAdministrativaSelected(
+      selectedFilters.some(
+        (filter) => filter.value === "categoriaAdministrativa",
+      ),
+    );
+    setIsFaixaEtariaSuperiorSelected(
+      selectedFilters.some((filter) => filter.value === "faixaEtariaSuperior"),
+    );
+    setIsOrganizacaoAcademicaSelected(
+      selectedFilters.some((filter) => filter.value === "organizacaoAcademica"),
+    );
+    setIsInstituicaoEnsinoSelected(
+      selectedFilters.some((filter) => filter.value === "instituicaoEnsino"),
+    );
+    setIsMunicipioSelected(
+      selectedFilters.some((filter) => filter.value === "municipio"),
+    );
 
     // Armazenar os filtros aplicados na última busca
     setAppliedTerritory(territory);
@@ -205,57 +251,97 @@ function FilterComponent() {
   const handleClearFilters = () => {
     setDisplayHistorical(false);
     setIsHistorical(false);
-    setType('university/count');
-    const limits = yearLimits['university/count'];
+    setType("university/count");
+    const limits = yearLimits["university/count"];
     setStartYear(limits.min);
     setEndYear(limits.max);
     setYear(limits.max);
     setYearRange([limits.min, limits.max]);
-    setCity('');
-    setTerritory('');
-    setFaixaPopulacional('');
-    setAglomerado('');
-    setGerencia('');
+    setCity("");
+    setTerritory("");
+    setFaixaPopulacional("");
+    setAglomerado("");
+    setGerencia("");
     setData(null);
     setError(null);
-    setTitle('');
+    setTitle("");
     setSelectedFilters([]);
 
     // Limpar também os filtros aplicados
-    setAppliedTerritory('');
-    setAppliedFaixaPopulacional('');
-    setAppliedAglomerado('');
-    setAppliedGerencia('');
+    setAppliedTerritory("");
+    setAppliedFaixaPopulacional("");
+    setAppliedAglomerado("");
+    setAppliedGerencia("");
     setAppliedSelectedFilters([]);
   };
 
-  const filterOptions = type === 'university_enrollment'
-    ? [{ value: 'modalidade', label: 'Modalidade' }, { value: 'categoriaAdministrativa', label: 'Categoria Administrativa' }, { value: 'faixaEtariaSuperior', label: 'Faixa Etária' },
-       { value: 'organizacaoAcademica', label: 'Organização Acadêmica'}, { value: 'instituicaoEnsino', label: 'Instituição de Ensino' }, { value: 'municipio', label: 'Município' }]
-    : type === 'university_teacher'
-    ? [{ value: 'regimeDeTrabalho', label: 'Regime de Trabalho' }, { value: 'formacaoDocente', label: 'Formação Docente' }, { value: 'categoriaAdministrativa', label: 'Categoria Administrativa' }, { value: 'organizacaoAcademica', label: 'Organização Acadêmica'}, { value: 'municipio', label: 'Município' }]
-    : type === 'course_count'
-    ?[{ value: 'modalidade', label: 'Modalidade' }, { value: 'categoriaAdministrativa', label: 'Categoria Administrativa' }, { value: 'organizacaoAcademica', label: 'Organização Acadêmica'}, { value: 'municipio', label: 'Município' }]
-    : [{ value: 'categoriaAdministrativa', label: 'Categoria Administrativa' }, { value: 'organizacaoAcademica', label: 'Organização Acadêmica'}, { value: 'municipio', label: 'Município' }];
+  const filterOptions =
+    type === "university_enrollment"
+      ? [
+          { value: "modalidade", label: "Modalidade" },
+          {
+            value: "categoriaAdministrativa",
+            label: "Categoria Administrativa",
+          },
+          { value: "faixaEtariaSuperior", label: "Faixa Etária" },
+          { value: "organizacaoAcademica", label: "Organização Acadêmica" },
+          { value: "instituicaoEnsino", label: "Instituição de Ensino" },
+          { value: "municipio", label: "Município" },
+        ]
+      : type === "university_teacher"
+        ? [
+            { value: "regimeDeTrabalho", label: "Regime de Trabalho" },
+            { value: "formacaoDocente", label: "Formação Docente" },
+            {
+              value: "categoriaAdministrativa",
+              label: "Categoria Administrativa",
+            },
+            { value: "organizacaoAcademica", label: "Organização Acadêmica" },
+            { value: "municipio", label: "Município" },
+          ]
+        : type === "course_count"
+          ? [
+              { value: "modalidade", label: "Modalidade" },
+              {
+                value: "categoriaAdministrativa",
+                label: "Categoria Administrativa",
+              },
+              { value: "organizacaoAcademica", label: "Organização Acadêmica" },
+              { value: "municipio", label: "Município" },
+            ]
+          : [
+              {
+                value: "categoriaAdministrativa",
+                label: "Categoria Administrativa",
+              },
+              { value: "organizacaoAcademica", label: "Organização Acadêmica" },
+              { value: "municipio", label: "Município" },
+            ];
 
   const titleMapping = {
     "university/count": "Número de intituições de ensino superior",
-    "university_enrollment": "Número de matrículas",
-    "university_teacher": "Número de docentes",
-    "course_count": "Número de cursos"
+    university_enrollment: "Número de matrículas",
+    university_teacher: "Número de docentes",
+    course_count: "Número de cursos",
   };
 
   // Lógica de filtros dependentes - baseado nos filtros de localização
   const baseFilteredMunicipios = useMemo(() => {
     const territorioLabel = territory ? Regioes[territory] : null;
-    const faixaLabel = faixaPopulacional ? FaixaPopulacional[faixaPopulacional] : null;
+    const faixaLabel = faixaPopulacional
+      ? FaixaPopulacional[faixaPopulacional]
+      : null;
 
     return Object.values(municipios).filter((m) => {
-      if (territorioLabel && m.territorioDesenvolvimento !== territorioLabel) return false;
+      if (territorioLabel && m.territorioDesenvolvimento !== territorioLabel)
+        return false;
       if (faixaLabel && m.faixaPopulacional !== faixaLabel) return false;
-      if (aglomerado && String(m.aglomerado) !== String(aglomerado)) return false;
+      if (aglomerado && String(m.aglomerado) !== String(aglomerado))
+        return false;
       if (gerencia) {
-        const gerencias = String(m.gerencia).split(',').map((g) => g.trim());
+        const gerencias = String(m.gerencia)
+          .split(",")
+          .map((g) => g.trim());
         if (!gerencias.includes(String(gerencia))) return false;
       }
       return true;
@@ -269,36 +355,59 @@ function FilterComponent() {
   const filteredMunicipioOptions = useMemo(() => {
     return Object.entries(municipios)
       .filter(([, m]) => baseFilteredMunicipios.includes(m))
-      .map(([key, { nomeMunicipio }]) => ({ value: key, label: nomeMunicipio }));
+      .map(([key, { nomeMunicipio }]) => ({
+        value: key,
+        label: nomeMunicipio,
+      }));
   }, [baseFilteredMunicipios]);
 
   const filteredTerritorioOptions = useMemo(() => {
-    const uniqueLabels = [...new Set(baseFilteredMunicipios.map((m) => m.territorioDesenvolvimento).filter(Boolean))];
+    const uniqueLabels = [
+      ...new Set(
+        baseFilteredMunicipios
+          .map((m) => m.territorioDesenvolvimento)
+          .filter(Boolean),
+      ),
+    ];
     return Object.entries(Regioes)
       .filter(([, label]) => uniqueLabels.includes(label))
       .map(([id, label]) => ({ value: id, label }));
   }, [baseFilteredMunicipios]);
 
   const filteredFaixaPopulacionalOptions = useMemo(() => {
-    const uniqueLabels = [...new Set(baseFilteredMunicipios.map((m) => m.faixaPopulacional).filter(Boolean))];
+    const uniqueLabels = [
+      ...new Set(
+        baseFilteredMunicipios.map((m) => m.faixaPopulacional).filter(Boolean),
+      ),
+    ];
     return Object.entries(FaixaPopulacional)
       .filter(([, label]) => uniqueLabels.includes(label))
       .map(([id, label]) => ({ value: id, label }));
   }, [baseFilteredMunicipios]);
 
   const filteredAglomeradoOptions = useMemo(() => {
-    return [...new Set(baseFilteredMunicipios.map((m) => m.aglomerado).filter((a) => a && a !== 'undefined'))]
+    return [
+      ...new Set(
+        baseFilteredMunicipios
+          .map((m) => m.aglomerado)
+          .filter((a) => a && a !== "undefined"),
+      ),
+    ]
       .sort((a, b) => Number(a) - Number(b))
       .map((a) => ({ value: a, label: `AG ${a}` }));
   }, [baseFilteredMunicipios]);
 
   const filteredGerenciaOptions = useMemo(() => {
-    return [...new Set(
-      baseFilteredMunicipios
-        .map((m) => m.gerencia)
-        .filter((g) => g && g !== 'undefined')
-        .flatMap((g) => (g.includes(',') ? g.split(',').map((x) => x.trim()) : [g]))
-    )]
+    return [
+      ...new Set(
+        baseFilteredMunicipios
+          .map((m) => m.gerencia)
+          .filter((g) => g && g !== "undefined")
+          .flatMap((g) =>
+            g.includes(",") ? g.split(",").map((x) => x.trim()) : [g],
+          ),
+      ),
+    ]
       .sort((a, b) => Number(a) - Number(b))
       .map((g) => ({ value: g, label: `${g}ª GRE` }));
   }, [baseFilteredMunicipios]);
@@ -309,7 +418,7 @@ function FilterComponent() {
       if (value && options.length > 0) {
         const exists = options.some((opt) => opt.value === value);
         if (!exists) {
-          setter('');
+          setter("");
         }
       }
     }, [value, setter, options]);
@@ -318,38 +427,60 @@ function FilterComponent() {
   // Aplicar limpeza de filtros inválidos
   useClearInvalidFilter(city, setCity, filteredMunicipioOptions);
   useClearInvalidFilter(territory, setTerritory, filteredTerritorioOptions);
-  useClearInvalidFilter(faixaPopulacional, setFaixaPopulacional, filteredFaixaPopulacionalOptions);
+  useClearInvalidFilter(
+    faixaPopulacional,
+    setFaixaPopulacional,
+    filteredFaixaPopulacionalOptions,
+  );
   useClearInvalidFilter(aglomerado, setAglomerado, filteredAglomeradoOptions);
   useClearInvalidFilter(gerencia, setGerencia, filteredGerenciaOptions);
 
   // Limpar filtros de localização quando um município específico é selecionado
   useEffect(() => {
     if (city) {
-      setTerritory('');
-      setFaixaPopulacional('');
-      setAglomerado('');
-      setGerencia('');
+      setTerritory("");
+      setFaixaPopulacional("");
+      setAglomerado("");
+      setGerencia("");
     }
   }, [city]);
 
-  const filteredCities = Object.entries(municipios).filter(([key, {
-    territorioDesenvolvimento,
-    faixaPopulacional: cityFaixaPopulacional,
-    aglomerado: cityAglomerado,
-    gerencia: cityGerencia
-  }]) => {
-    // Verifica todas as condições selecionadas
-    const matchesTerritory = !territory || territorioDesenvolvimento === Regioes[territory];
-    const matchesFaixaPopulacional = !faixaPopulacional || cityFaixaPopulacional === FaixaPopulacional[faixaPopulacional];
-    const matchesAglomerado = !aglomerado || cityAglomerado === aglomerado;
+  const filteredCities = Object.entries(municipios).filter(
+    ([
+      key,
+      {
+        territorioDesenvolvimento,
+        faixaPopulacional: cityFaixaPopulacional,
+        aglomerado: cityAglomerado,
+        gerencia: cityGerencia,
+      },
+    ]) => {
+      // Verifica todas as condições selecionadas
+      const matchesTerritory =
+        !territory || territorioDesenvolvimento === Regioes[territory];
+      const matchesFaixaPopulacional =
+        !faixaPopulacional ||
+        cityFaixaPopulacional === FaixaPopulacional[faixaPopulacional];
+      const matchesAglomerado = !aglomerado || cityAglomerado === aglomerado;
 
-    // Para gerência, verificar se a gerencia selecionada está contida na string de gerencias da cidade
-    // (considerando que uma cidade pode ter múltiplas gerencias separadas por vírgula)
-    const matchesGerencia = !gerencia || cityGerencia.split(',').map(g => g.trim()).includes(gerencia);
+      // Para gerência, verificar se a gerencia selecionada está contida na string de gerencias da cidade
+      // (considerando que uma cidade pode ter múltiplas gerencias separadas por vírgula)
+      const matchesGerencia =
+        !gerencia ||
+        cityGerencia
+          .split(",")
+          .map((g) => g.trim())
+          .includes(gerencia);
 
-    // Retorna true apenas se TODAS as condições selecionadas são atendidas
-    return matchesTerritory && matchesFaixaPopulacional && matchesAglomerado && matchesGerencia;
-  });
+      // Retorna true apenas se TODAS as condições selecionadas são atendidas
+      return (
+        matchesTerritory &&
+        matchesFaixaPopulacional &&
+        matchesAglomerado &&
+        matchesGerencia
+      );
+    },
+  );
 
   const typeOptions = Object.entries(titleMapping).map(([key, label]) => ({
     value: key,
@@ -361,27 +492,33 @@ function FilterComponent() {
     label: value,
   }));
 
-  const faixaPopulacionalOptions = Object.entries(FaixaPopulacional).map(([key, value]) => ({
-    value: key,
-    label: value,
-  }));
+  const faixaPopulacionalOptions = Object.entries(FaixaPopulacional).map(
+    ([key, value]) => ({
+      value: key,
+      label: value,
+    }),
+  );
 
-  const gerenciaOptions = [...new Set(Object.values(municipios).map(m => m.gerencia))]
-    .flatMap(gerencia => gerencia.split(',').map(g => g.trim()))
+  const gerenciaOptions = [
+    ...new Set(Object.values(municipios).map((m) => m.gerencia)),
+  ]
+    .flatMap((gerencia) => gerencia.split(",").map((g) => g.trim()))
     .filter(Boolean)
     .sort((a, b) => parseInt(a) - parseInt(b))
-    .map(gerencia => ({
+    .map((gerencia) => ({
       value: gerencia,
-      label: gerencia + 'ª GRE',
+      label: gerencia + "ª GRE",
     }));
 
-  const aglomeradoOptions = [...new Set(Object.values(municipios).map(m => m.aglomerado))]
-    .flatMap(aglomerado => aglomerado.split(',').map(a => a.trim()))
+  const aglomeradoOptions = [
+    ...new Set(Object.values(municipios).map((m) => m.aglomerado)),
+  ]
+    .flatMap((aglomerado) => aglomerado.split(",").map((a) => a.trim()))
     .filter(Boolean)
     .sort((a, b) => parseInt(a) - parseInt(b))
-    .map(aglomerado => ({
+    .map((aglomerado) => ({
       value: aglomerado,
-      label: 'AG ' + aglomerado,
+      label: "AG " + aglomerado,
     }));
 
   const cityOptions = filteredCities.map(([key, { nomeMunicipio }]) => ({
@@ -398,60 +535,77 @@ function FilterComponent() {
   return (
     <div className="app-container">
       <div className="flex flex-col gap-4 p-0 m-0">
-
-          {/* Tipo + Filtros Múltiplos + Botão Mais Filtros - Primeira linha */}
-          <div className="md:col-span-3">
-            <div className="flex flex-col lg:flex-row items-end gap-4">
-              <div className="w-full lg:flex-1">
-            <label htmlFor="typeSelect" className="block text-sm font-medium text-gray-700 mb-1">Tipo:</label>
-            <Select
-              id="typeSelect"
-              value={typeOptions.find(option => option.value === type)}
-              onChange={(selectedOption) => {
-                setType(selectedOption.value);
-                setSelectedFilters([]);
-                // Se mudou para docentes, garantir que não há filtros selecionados
-                if (selectedOption.value === 'university_teacher') {
+        {/* Tipo + Filtros Múltiplos + Botão Mais Filtros - Primeira linha */}
+        <div className="md:col-span-3">
+          <div className="flex flex-col lg:flex-row items-end gap-4">
+            <div className="w-full lg:flex-1">
+              <label
+                htmlFor="typeSelect"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Tipo:
+              </label>
+              <Select
+                id="typeSelect"
+                value={typeOptions.find((option) => option.value === type)}
+                onChange={(selectedOption) => {
+                  setType(selectedOption.value);
                   setSelectedFilters([]);
-                }
-              }}
-              options={typeOptions}
-              placeholder="Selecione o tipo"
-              size="xs"
-            />
-          </div>
+                  // Se mudou para docentes, garantir que não há filtros selecionados
+                  if (selectedOption.value === "university_teacher") {
+                    setSelectedFilters([]);
+                  }
+                }}
+                options={typeOptions}
+                placeholder="Selecione o tipo"
+                size="xs"
+              />
+            </div>
 
-              <div className="w-full lg:flex-1">
-                <label htmlFor="multiFilterSelect" className="block text-sm font-medium text-gray-700 mb-1">Filtros:</label>
+            <div className="w-full lg:flex-1">
+              <label
+                htmlFor="multiFilterSelect"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Filtros:
+              </label>
               <Select
                 id="multiFilterSelect"
                 value={selectedFilters}
                 onChange={(newValue) => {
                   // Para docentes (university_teacher), permitir apenas um filtro por vez
-                  if (type === 'university_teacher') {
+                  if (type === "university_teacher") {
                     setSelectedFilters(newValue.slice(-1)); // Manter apenas o último selecionado
                     return;
                   }
 
                   // Validação para impedir combinação de regime + formação docente (para outros tipos)
-                  const hasRegime = newValue.some(filter => filter.value === 'regimeDeTrabalho');
-                  const hasFormacao = newValue.some(filter => filter.value === 'formacaoDocente');
+                  const hasRegime = newValue.some(
+                    (filter) => filter.value === "regimeDeTrabalho",
+                  );
+                  const hasFormacao = newValue.some(
+                    (filter) => filter.value === "formacaoDocente",
+                  );
 
                   if (hasRegime && hasFormacao) {
                     // Se está tentando adicionar os dois, manter apenas o último selecionado
                     const lastSelected = newValue[newValue.length - 1];
-                    if (lastSelected.value === 'regimeDeTrabalho') {
+                    if (lastSelected.value === "regimeDeTrabalho") {
                       // Removeu formação docente, manter regime
-                      setSelectedFilters(newValue.filter(f => f.value !== 'formacaoDocente'));
+                      setSelectedFilters(
+                        newValue.filter((f) => f.value !== "formacaoDocente"),
+                      );
                     } else {
                       // Removeu regime, manter formação docente
-                      setSelectedFilters(newValue.filter(f => f.value !== 'regimeDeTrabalho'));
+                      setSelectedFilters(
+                        newValue.filter((f) => f.value !== "regimeDeTrabalho"),
+                      );
                     }
                     return;
                   }
 
-                    const isHistoricalRange = yearRange[0] !== yearRange[1];
-                    if (isHistoricalRange) {
+                  const isHistoricalRange = yearRange[0] !== yearRange[1];
+                  if (isHistoricalRange) {
                     setSelectedFilters(newValue.slice(-1));
                   } else if (newValue.length <= 2) {
                     setSelectedFilters(newValue);
@@ -462,135 +616,177 @@ function FilterComponent() {
                 options={filterOptions}
                 isMulti
                 placeholder={
-                  type === 'university_teacher'
+                  type === "university_teacher"
                     ? "Selecione 1 filtro (docentes)"
-                      : yearRange[0] !== yearRange[1]
+                    : yearRange[0] !== yearRange[1]
                       ? "Selecione 1 filtro"
                       : "Selecione até 2 filtros"
                 }
                 size="xs"
               />
             </div>
+          </div>
+        </div>
 
-              {/* Botão de toggle para filtros adicionais */}
-              <div className="w-full lg:w-auto">
-                <Button
-                  variant="outlined"
-                  size="small"
-                  startIcon={filtersExpanded ? <ExpandLess /> : <ExpandMore />}
-                  onClick={() => setFiltersExpanded(!filtersExpanded)}
-                  sx={{
-                    minWidth: 'auto',
-                    padding: '8px 16px',
-                    whiteSpace: 'nowrap',
-                    height: 'fit-content',
-                    mb: 0.5,
-                    width: { xs: '100%', lg: 'auto' }
-                  }}
-                >
-                  {filtersExpanded ? 'Menos Filtros' : 'Mais Filtros'}
-                </Button>
-              </div>
+        {/* Filtros sempre visiveis */}
+        <div className="md:col-span-3">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {/* Território */}
+            <div className="md:col-span-1">
+              <Select
+                id="territorySelect"
+                value={
+                  filteredTerritorioOptions.find(
+                    (option) => option.value === territory,
+                  ) || null
+                }
+                onChange={(selectedOption) => {
+                  setTerritory(selectedOption ? selectedOption.value : "");
+                  setCity("");
+                }}
+                options={filteredTerritorioOptions}
+                placeholder="Território de Desenvolvimento"
+                size="xs"
+                isClearable={true}
+                disabled={otherLocalityDisabled}
+              />
+            </div>
+
+            {/* Faixa Populacional */}
+            <div className="md:col-span-1">
+              <Select
+                id="faixaPopulacionalSelect"
+                value={
+                  filteredFaixaPopulacionalOptions.find(
+                    (option) => option.value === faixaPopulacional,
+                  ) || null
+                }
+                onChange={(selectedOption) => {
+                  setFaixaPopulacional(
+                    selectedOption ? selectedOption.value : "",
+                  );
+                  setCity("");
+                }}
+                options={filteredFaixaPopulacionalOptions}
+                placeholder="Faixa Populacional"
+                size="xs"
+                isClearable={true}
+                disabled={otherLocalityDisabled}
+              />
+            </div>
+
+            {/* Aglomerado */}
+            <div className="md:col-span-1">
+              <Select
+                id="aglomeradoSelect"
+                value={
+                  filteredAglomeradoOptions.find(
+                    (option) => option.value === aglomerado,
+                  ) || null
+                }
+                onChange={(selectedOption) =>
+                  setAglomerado(selectedOption ? selectedOption.value : "")
+                }
+                options={filteredAglomeradoOptions}
+                placeholder="Aglomerado - AG"
+                size="xs"
+                isClearable={true}
+                disabled={otherLocalityDisabled}
+              />
+            </div>
+
+            {/* Gerência */}
+            <div className="md:col-span-1">
+              <Select
+                id="gerenciaSelect"
+                value={
+                  filteredGerenciaOptions.find(
+                    (option) => option.value === gerencia,
+                  ) || null
+                }
+                onChange={(selectedOption) =>
+                  setGerencia(selectedOption ? selectedOption.value : "")
+                }
+                options={filteredGerenciaOptions}
+                placeholder="Gerência Regional de Ensino - GRE"
+                size="xs"
+                isClearable={true}
+                disabled={otherLocalityDisabled}
+              />
+            </div>
+
+            {/* Cidade */}
+            <div className="md:col-span-1">
+              <Select
+                id="citySelect"
+                value={
+                  filteredMunicipioOptions.find(
+                    (option) => option.value === city,
+                  ) || null
+                }
+                onChange={(selectedOption) =>
+                  setCity(selectedOption ? selectedOption.value : "")
+                }
+                options={filteredMunicipioOptions}
+                placeholder="Município"
+                size="xs"
+                isClearable={true}
+              />
             </div>
           </div>
+        </div>
 
-          {/* Filtros recolhíveis */}
-          <Collapse in={filtersExpanded} timeout="auto" unmountOnExit>
-            <div className="md:col-span-3">
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                {/* Território */}
-                <div className="md:col-span-1">
-                  <Select
-                    id="territorySelect"
-                    value={filteredTerritorioOptions.find(option => option.value === territory) || null}
-                    onChange={(selectedOption) => {
-                      setTerritory(selectedOption ? selectedOption.value : '');
-                      setCity('');
-                    }}
-                    options={filteredTerritorioOptions}
-                    placeholder="Território de Desenvolvimento"
-                    size="xs"
-                    isClearable={true}
-                    disabled={otherLocalityDisabled}
-                  />
-                </div>
-
-                {/* Faixa Populacional */}
-                <div className="md:col-span-1">
-                  <Select
-                    id="faixaPopulacionalSelect"
-                    value={filteredFaixaPopulacionalOptions.find(option => option.value === faixaPopulacional) || null}
-                    onChange={(selectedOption) => {
-                      setFaixaPopulacional(selectedOption ? selectedOption.value : '');
-                      setCity('');
-                    }}
-                    options={filteredFaixaPopulacionalOptions}
-                    placeholder="Faixa Populacional"
-                    size="xs"
-                    isClearable={true}
-                    disabled={otherLocalityDisabled}
-                  />
-                </div>
-
-                {/* Aglomerado */}
-                <div className="md:col-span-1">
-                  <Select
-                    id="aglomeradoSelect"
-                    value={filteredAglomeradoOptions.find(option => option.value === aglomerado) || null}
-                    onChange={(selectedOption) => setAglomerado(selectedOption ? selectedOption.value : '')}
-                    options={filteredAglomeradoOptions}
-                    placeholder="Aglomerado - AG"
-                    size="xs"
-                    isClearable={true}
-                    disabled={otherLocalityDisabled}
-                  />
-                </div>
-
-                {/* Gerência */}
-                <div className="md:col-span-1">
-                  <Select
-                    id="gerenciaSelect"
-                    value={filteredGerenciaOptions.find(option => option.value === gerencia) || null}
-                    onChange={(selectedOption) => setGerencia(selectedOption ? selectedOption.value : '')}
-                    options={filteredGerenciaOptions}
-                    placeholder="Gerência Regional de Ensino - GRE"
-                    size="xs"
-                    isClearable={true}
-                    disabled={otherLocalityDisabled}
-                  />
-                </div>
-
-                {/* Cidade */}
-                <div className="md:col-span-1">
-                  <Select
-                    id="citySelect"
-                    value={filteredMunicipioOptions.find(option => option.value === city) || null}
-                    onChange={(selectedOption) => setCity(selectedOption ? selectedOption.value : '')}
-                    options={filteredMunicipioOptions}
-                    placeholder="Município"
-                    size="xs"
-                    isClearable={true}
-                  />
-                </div>
-              </div>
+        {/* Período - Seleção de Anos (Substituindo o Slider) */}
+        <div className="md:col-span-3">
+          <div className="flex flex-col sm:flex-row gap-4 py-4">
+            <div className="flex-1">
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                De:
+              </label>
+              <Select
+                id="startYearSelect"
+                options={yearOptions}
+                value={yearOptions.find((opt) => opt.value === yearRange[0])}
+                onChange={(selected) =>
+                  setYearRange([selected.value, yearRange[1]])
+                }
+                size="xs"
+              />
             </div>
-          </Collapse>
 
-          {/* Período - Todas as colunas, terceira linha */}
-          <div className="md:col-span-3">
-            <YearRangeSlider
-              minYear={getYearLimits.min}
-              maxYear={getYearLimits.max}
-              value={yearRange}
-              onChange={setYearRange}
-            />
+            <div className="flex-1">
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Até:
+              </label>
+              <Select
+                id="endYearSelect"
+                options={yearOptions}
+                value={yearOptions.find((opt) => opt.value === yearRange[1])}
+                onChange={(selected) =>
+                  setYearRange([yearRange[0], selected.value])
+                }
+                size="xs"
+              />
+            </div>
           </div>
+        </div>
 
-          {/* Botões - Ocupa todo o espaço da linha */}
-          <div className="md:col-span-3 flex flex-col justify-end">
-            <div className="flex flex-col sm:flex-row gap-3 justify-end items-end">
-              {/* Toggle para modo consolidado (apenas quando há filtros territoriais combinados com outros filtros aplicados na última busca) */}
-              {(appliedTerritory || appliedFaixaPopulacional || appliedAglomerado || appliedGerencia) && (isModalidadeSelected || isRegimeSelected || isFormacaoDocenteSelected || isCategoriaAdministrativaSelected || isFaixaEtariaSuperiorSelected || isOrganizacaoAcademicaSelected || isInstituicaoEnsinoSelected) && !isMunicipioSelected && (
+        {/* Botões - Ocupa todo o espaço da linha */}
+        <div className="md:col-span-3 flex flex-col justify-end">
+          <div className="flex flex-col sm:flex-row gap-3 justify-end items-end">
+            {/* Toggle para modo consolidado (apenas quando há filtros territoriais combinados com outros filtros aplicados na última busca) */}
+            {(appliedTerritory ||
+              appliedFaixaPopulacional ||
+              appliedAglomerado ||
+              appliedGerencia) &&
+              (isModalidadeSelected ||
+                isRegimeSelected ||
+                isFormacaoDocenteSelected ||
+                isCategoriaAdministrativaSelected ||
+                isFaixaEtariaSuperiorSelected ||
+                isOrganizacaoAcademicaSelected ||
+                isInstituicaoEnsinoSelected) &&
+              !isMunicipioSelected && (
                 <div className="flex items-center space-x-2">
                   <label className="flex items-center pb-2 space-x-2 cursor-pointer">
                     <Switch
@@ -599,28 +795,34 @@ function FilterComponent() {
                       color="primary"
                       size="small"
                       sx={{
-                        '& .MuiSwitch-thumb': {
-                          backgroundColor: showConsolidated ? '#1976d2' : '#fafafa',
+                        "& .MuiSwitch-thumb": {
+                          backgroundColor: showConsolidated
+                            ? "#1976d2"
+                            : "#fafafa",
                         },
-                        '& .MuiSwitch-track': {
-                          backgroundColor: showConsolidated ? '#1976d2' : '#ccc',
+                        "& .MuiSwitch-track": {
+                          backgroundColor: showConsolidated
+                            ? "#1976d2"
+                            : "#ccc",
                         },
                       }}
                     />
-                    <span className="text-gray-700">Mostrar dados consolidados</span>
+                    <span className="text-gray-700">
+                      Mostrar dados consolidados
+                    </span>
                   </label>
                 </div>
               )}
-              <Button
-                variant="contained"
-                color="primary"
-                onClick={handleFilterClick}
-                className="w-full sm:w-auto"
-              >
-                Mostrar resultados
-              </Button>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleFilterClick}
+              className="w-full sm:w-auto"
+            >
+              Mostrar resultados
+            </Button>
 
-              {/* <Button
+            {/* <Button
                 variant="contained"
                 color="success"
                 onClick={handleExportTable}
@@ -632,45 +834,44 @@ function FilterComponent() {
                 Exportar Tabelão
               </Button> */}
 
-              <Button
-                style={{
-                  backgroundColor: '#f0f0f0',
-                  color: '#000',
-                }}
-                variant="contained"
-                onClick={handleClearFilters}
-                className="w-full sm:w-auto"
-              >
-                Limpar
-              </Button>
+            <Button
+              style={{
+                backgroundColor: "#f0f0f0",
+                color: "#000",
+              }}
+              variant="contained"
+              onClick={handleClearFilters}
+              className="w-full sm:w-auto"
+            >
+              Limpar
+            </Button>
           </div>
         </div>
       </div>
 
       <hr className="divider" />
 
-      {isLoading && (
-        <Loading />
-      )}
+      {isLoading && <Loading />}
       {error && (
         <div className="error-message">
           <p>{error}</p>
-            </div>
-          )}
+        </div>
+      )}
 
       {!isLoading && !error && !data && (
         <Typography
           variant="body1"
           sx={{
-            textAlign: 'center',
-            fontSize: '18px',
-            fontWeight: 'bold',
-            margin: '20px auto',
-            maxWidth: '400px',
-            color: theme.palette.primary.main
+            textAlign: "center",
+            fontSize: "18px",
+            fontWeight: "bold",
+            margin: "20px auto",
+            maxWidth: "400px",
+            color: theme.palette.primary.main,
           }}
         >
-          Selecione os filtros desejados e clique em "Filtrar" para montar uma consulta.
+          Selecione os filtros desejados e clique em "Filtrar" para montar uma
+          consulta.
         </Typography>
       )}
 
@@ -690,7 +891,11 @@ function FilterComponent() {
         faixaPopulacional={faixaPopulacional}
         aglomerado={aglomerado}
         gerencia={gerencia}
-        citiesList={territory || faixaPopulacional || aglomerado || gerencia ? filteredCities : []}
+        citiesList={
+          territory || faixaPopulacional || aglomerado || gerencia
+            ? filteredCities
+            : []
+        }
         onDataFetched={setData}
         onError={setError}
         onLoading={setIsLoading}
@@ -702,7 +907,9 @@ function FilterComponent() {
       {!isLoading && !error && data && title ? (
         <DataTable
           data={data.finalResult ? data.finalResult : data}
-          municipioData={data.allResults && data.allResults.length > 0 ? data.allResults : []}
+          municipioData={
+            data.allResults && data.allResults.length > 0 ? data.allResults : []
+          }
           isHistorical={displayHistorical}
           type={type}
           isModalidadeSelected={isModalidadeSelected}
@@ -721,15 +928,19 @@ function FilterComponent() {
             setPaginationLimit(newLimit);
             setIsLoading(true); // Mostrar loading ao mudar paginação
           }}
-          fetchAllDataConfig={isMunicipioSelected ? {
-            type,
-            year: yearRange[0],
-            isHistorical: displayHistorical,
-            startYear: yearRange[0],
-            endYear: yearRange[1],
-            city,
-            selectedFilters
-          } : null}
+          fetchAllDataConfig={
+            isMunicipioSelected
+              ? {
+                  type,
+                  year: yearRange[0],
+                  isHistorical: displayHistorical,
+                  startYear: yearRange[0],
+                  endYear: yearRange[1],
+                  city,
+                  selectedFilters,
+                }
+              : null
+          }
         />
       ) : null}
     </div>

--- a/src/components/pages/education/rate/FiltrosRateComponent.jsx
+++ b/src/components/pages/education/rate/FiltrosRateComponent.jsx
@@ -1,42 +1,46 @@
-import { Button, Typography, Box } from '@mui/material';
-import React, { useEffect, useMemo, useState } from 'react';
-import { useTheme } from '@mui/material/styles';
-import { Select } from '../../../ui';
-import YearRangeSlider from '../../../ui/YearRangeSlider';
-import '../../../../style/RevenueTableContainer.css';
-import '../../../../style/TableFilters.css';
-import ApiRateContainer from './ApiRateComponent.jsx';
-import TableRateComponent from './TableRateComponent.jsx';
+import { Button, Typography, Box } from "@mui/material";
+import React, { useEffect, useMemo, useState } from "react";
+import { useTheme } from "@mui/material/styles";
+import { Select } from "../../../ui";
+import YearRangeSlider from "../../../ui/YearRangeSlider";
+import "../../../../style/RevenueTableContainer.css";
+import "../../../../style/TableFilters.css";
+import ApiRateContainer from "./ApiRateComponent.jsx";
+import TableRateComponent from "./TableRateComponent.jsx";
 import { Loading } from "../../../ui";
 
 function FiltrosRateComponent() {
-  const yearLimits = useMemo(() => ({
-    pop_out_school: { min: 2019, max: 2023 },
-    adjusted_liquid_frequency: { min: 2019, max: 2023 },
-    iliteracy_rate: { min: 2019, max: 2023 },
-    superior_education_conclusion_tax: { min: 2019, max: 2023 },
-    basic_education_conclusion: { min: 2019, max: 2023 },
-    instruction_level: { min: 2016, max: 2023 }
-  }), []);
+  const yearLimits = useMemo(
+    () => ({
+      pop_out_school: { min: 2019, max: 2023 },
+      adjusted_liquid_frequency: { min: 2019, max: 2023 },
+      iliteracy_rate: { min: 2019, max: 2023 },
+      superior_education_conclusion_tax: { min: 2019, max: 2023 },
+      basic_education_conclusion: { min: 2019, max: 2023 },
+      instruction_level: { min: 2016, max: 2023 },
+    }),
+    [],
+  );
 
-  const [type, setType] = useState('pop_out_school');
-  const [filteredType, setFilteredType] = useState('pop_out_school');
+  const [type, setType] = useState("pop_out_school");
+  const [filteredType, setFilteredType] = useState("pop_out_school");
   const [isHistorical, setIsHistorical] = useState(false);
   const [data, setData] = useState(null);
   const [error, setError] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [title, setTitle] = useState('');
+  const [title, setTitle] = useState("");
   const [selectedFilters, setSelectedFilters] = useState([]);
   const [isEtapaSelected, setIsEtapaSelected] = useState(false);
   const [isLocalidadeSelected, setIsLocalidadeSelected] = useState(false);
   const [isFaixaEtariaSelected, setIsFaixaEtariaSelected] = useState(false);
-  const [isInstructionLevelSelected, setIsInstructionLevelSelected] = useState(false);
+  const [isInstructionLevelSelected, setIsInstructionLevelSelected] =
+    useState(false);
   const [displayHistorical, setDisplayHistorical] = useState(false);
   const [year, setYear] = useState(yearLimits.pop_out_school.max);
   const [filteredYear, setFilteredYear] = useState(null);
   const [startYear, setStartYear] = useState(yearLimits.pop_out_school.min);
   const [endYear, setEndYear] = useState(yearLimits.pop_out_school.max);
-  
+
   // Estado para o range slider
   const [yearRange, setYearRange] = useState([2019, 2023]);
 
@@ -47,15 +51,19 @@ function FiltrosRateComponent() {
 
   // Usar getYearLimits para yearOptions
   const yearOptions = useMemo(() => {
-    if (type === 'pop_out_school' || type === 'adjusted_liquid_frequency' ||
-        type === 'iliteracy_rate' || type === 'superior_education_conclusion_tax' ||
-        type === 'basic_education_conclusion') {
+    if (
+      type === "pop_out_school" ||
+      type === "adjusted_liquid_frequency" ||
+      type === "iliteracy_rate" ||
+      type === "superior_education_conclusion_tax" ||
+      type === "basic_education_conclusion"
+    ) {
       // Para todos os tipos, apenas os anos específicos disponíveis
       return [2019, 2022, 2023].map((year) => ({
         value: year,
         label: year.toString(),
       }));
-    } else if (type === 'instruction_level') {
+    } else if (type === "instruction_level") {
       // Para instruction_level, apenas os anos específicos disponíveis
       return [2016, 2017, 2018, 2019, 2022, 2023].map((year) => ({
         value: year,
@@ -65,7 +73,7 @@ function FiltrosRateComponent() {
 
     return Array.from(
       { length: getYearLimits.max - getYearLimits.min + 1 },
-      (_, i) => getYearLimits.min + i
+      (_, i) => getYearLimits.min + i,
     ).map((year) => ({
       value: year,
       label: year.toString(),
@@ -74,14 +82,18 @@ function FiltrosRateComponent() {
 
   // Atualizar os anos quando os limites mudarem
   useEffect(() => {
-    if (type === 'pop_out_school' || type === 'adjusted_liquid_frequency' ||
-        type === 'iliteracy_rate' || type === 'superior_education_conclusion_tax' ||
-        type === 'basic_education_conclusion') {
+    if (
+      type === "pop_out_school" ||
+      type === "adjusted_liquid_frequency" ||
+      type === "iliteracy_rate" ||
+      type === "superior_education_conclusion_tax" ||
+      type === "basic_education_conclusion"
+    ) {
       setYear(2023); // Ano mais recente disponível
       setStartYear(2019);
       setEndYear(2023);
       setYearRange([2019, 2023]);
-    } else if (type === 'instruction_level') {
+    } else if (type === "instruction_level") {
       setYear(2023); // Ano mais recente disponível
       setStartYear(2016);
       setEndYear(2023);
@@ -97,16 +109,24 @@ function FiltrosRateComponent() {
   // Adicionar este useEffect para ajustar filtros específicos para cada tipo
   useEffect(() => {
     // Ajustar filtros específicos para cada tipo
-    if (type === 'pop_out_school' || type === 'adjusted_liquid_frequency') {
+    if (type === "pop_out_school" || type === "adjusted_liquid_frequency") {
       // Garantir que faixa etária esteja selecionada
-      const faixaEtariaFilter = { value: 'faixaEtaria', label: 'Faixa Etária (Obrigatório)' };
-      if (!selectedFilters.some(filter => filter.value === 'faixaEtaria')) {
+      const faixaEtariaFilter = {
+        value: "faixaEtaria",
+        label: "Faixa Etária (Obrigatório)",
+      };
+      if (!selectedFilters.some((filter) => filter.value === "faixaEtaria")) {
         setSelectedFilters([faixaEtariaFilter]);
       }
-    } else if (type === 'instruction_level') {
+    } else if (type === "instruction_level") {
       // Garantir que nível de instrução esteja selecionado
-      const instructionLevelFilter = { value: 'instruction_level', label: 'Nível de Instrução (Obrigatório)' };
-      if (!selectedFilters.some(filter => filter.value === 'instruction_level')) {
+      const instructionLevelFilter = {
+        value: "instruction_level",
+        label: "Nível de Instrução (Obrigatório)",
+      };
+      if (
+        !selectedFilters.some((filter) => filter.value === "instruction_level")
+      ) {
         setSelectedFilters([instructionLevelFilter]);
       }
     }
@@ -118,12 +138,14 @@ function FiltrosRateComponent() {
     setError(null);
     setData(null);
     // Limpar o título antes de definir um novo
-    setTitle('');
+    setTitle("");
 
     // Determina se é série histórica baseado no yearRange
     const isHistoricalRange = yearRange[0] !== yearRange[1];
-    const yearDisplay = isHistoricalRange ? `${yearRange[0]}-${yearRange[1]}` : yearRange[0];
-    
+    const yearDisplay = isHistoricalRange
+      ? `${yearRange[0]}-${yearRange[1]}`
+      : yearRange[0];
+
     setIsHistorical(isHistoricalRange);
     setDisplayHistorical(isHistoricalRange);
     setFilteredType(type);
@@ -137,16 +159,21 @@ function FiltrosRateComponent() {
 
     // Adicionar filtros adicionais selecionados
     if (selectedFilters.length > 0) {
-      const filterNames = selectedFilters.map(filter => {
-        switch(filter.value) {
-          case 'etapa': return 'Etapa de Ensino';
-          case 'localidade': return 'Localidade';
-          case 'faixaEtaria': return 'Faixa Etária';
-          case 'instruction_level': return 'Nível de Instrução';
-          default: return filter.value;
+      const filterNames = selectedFilters.map((filter) => {
+        switch (filter.value) {
+          case "etapa":
+            return "Etapa de Ensino";
+          case "localidade":
+            return "Localidade";
+          case "faixaEtaria":
+            return "Faixa Etária";
+          case "instruction_level":
+            return "Nível de Instrução";
+          default:
+            return filter.value;
         }
       });
-      filterInfo.push(`Filtros: ${filterNames.join(', ')}`);
+      filterInfo.push(`Filtros: ${filterNames.join(", ")}`);
     }
 
     // Construir o título completo
@@ -154,23 +181,31 @@ function FiltrosRateComponent() {
 
     // Adicionar informações de filtro se houver
     if (filterInfo.length > 0) {
-      fullTitle += ` | ${filterInfo.join(' | ')}`;
+      fullTitle += ` | ${filterInfo.join(" | ")}`;
     }
 
-    setTitle(type ? fullTitle : '');
+    setTitle(type ? fullTitle : "");
 
-    setIsEtapaSelected(selectedFilters.some(filter => filter.value === 'etapa'));
-    setIsLocalidadeSelected(selectedFilters.some(filter => filter.value === 'localidade'));
-    setIsFaixaEtariaSelected(selectedFilters.some(filter => filter.value === 'faixaEtaria'));
-    setIsInstructionLevelSelected(selectedFilters.some(filter => filter.value === 'instruction_level'));
+    setIsEtapaSelected(
+      selectedFilters.some((filter) => filter.value === "etapa"),
+    );
+    setIsLocalidadeSelected(
+      selectedFilters.some((filter) => filter.value === "localidade"),
+    );
+    setIsFaixaEtariaSelected(
+      selectedFilters.some((filter) => filter.value === "faixaEtaria"),
+    );
+    setIsInstructionLevelSelected(
+      selectedFilters.some((filter) => filter.value === "instruction_level"),
+    );
   };
 
   const handleClearFilters = () => {
     setDisplayHistorical(false);
     setIsHistorical(false);
-    setType('pop_out_school');
-    setFilteredType('pop_out_school');
-    const limits = yearLimits['pop_out_school'];
+    setType("pop_out_school");
+    setFilteredType("pop_out_school");
+    const limits = yearLimits["pop_out_school"];
     setStartYear(limits.min);
     setEndYear(limits.max);
     setYear(limits.max);
@@ -178,7 +213,7 @@ function FiltrosRateComponent() {
     setYearRange([limits.min, limits.max]);
     setData(null);
     setError(null);
-    setTitle('');
+    setTitle("");
     setSelectedFilters([]);
     setIsEtapaSelected(false);
     setIsLocalidadeSelected(false);
@@ -192,7 +227,7 @@ function FiltrosRateComponent() {
     iliteracy_rate: "Taxa de analfabetismo",
     superior_education_conclusion_tax: "Taxa de conclusão do ensino superior",
     basic_education_conclusion: "Taxa de conclusão do ensino básico",
-    instruction_level: "Nível de instrução"
+    instruction_level: "Nível de instrução",
   };
 
   const typeOptions = Object.entries(titleMapping).map(([key, label]) => ({
@@ -204,163 +239,264 @@ function FiltrosRateComponent() {
     menuPortal: (base) => ({ ...base, zIndex: 9999 }),
   };
 
-  const filterOptions = type === 'pop_out_school' || type === 'adjusted_liquid_frequency'
-    ? [{ value: 'faixaEtaria', label: 'Faixa Etária (Obrigatório)' }]
-    : type === 'iliteracy_rate' || type === 'superior_education_conclusion_tax' || type === 'basic_education_conclusion'
-    ? [
-        { value: 'localidade', label: 'Localidade' },
-        { value: 'faixaEtaria', label: 'Faixa Etária' }
-      ]
-    : type === 'instruction_level'
-    ? [
-        { value: 'instruction_level', label: 'Nível de Instrução (Obrigatório)' },
-        { value: 'localidade', label: 'Localidade' },
-        { value: 'faixaEtaria', label: 'Faixa Etária' }
-      ]
-    : [];
+  const filterOptions =
+    type === "pop_out_school" || type === "adjusted_liquid_frequency"
+      ? [{ value: "faixaEtaria", label: "Faixa Etária (Obrigatório)" }]
+      : type === "iliteracy_rate" ||
+          type === "superior_education_conclusion_tax" ||
+          type === "basic_education_conclusion"
+        ? [
+            { value: "localidade", label: "Localidade" },
+            { value: "faixaEtaria", label: "Faixa Etária" },
+          ]
+        : type === "instruction_level"
+          ? [
+              {
+                value: "instruction_level",
+                label: "Nível de Instrução (Obrigatório)",
+              },
+              { value: "localidade", label: "Localidade" },
+              { value: "faixaEtaria", label: "Faixa Etária" },
+            ]
+          : [];
 
   const theme = useTheme();
 
   return (
     <div className="app-container">
       <div className="flex flex-col gap-4 p-0 m-0">
-        
-          {/* Tipo + Filtros + Informações - Primeira linha */}
-          <div className="md:col-span-3">
-            <div className="flex flex-col lg:flex-row items-start gap-4">
-              <div className="w-full lg:flex-1">
-                <label htmlFor="typeSelect" className="block text-sm font-medium text-gray-700 mb-1">Tipo:</label>
-                <Select
-                  id="typeSelect"
-                  value={typeOptions.find(option => option.value === type)}
-                  onChange={(selectedOption) => {
-                    setType(selectedOption.value);
-                    setSelectedFilters([]);
-                  }}
-                  options={typeOptions}
-                  placeholder="Selecione o tipo"
-                  size="xs"
-                />
-              </div>
-
-              <div className="w-full lg:flex-1">
-                <label htmlFor="multiFilterSelect" className="block text-sm font-medium text-gray-700 mb-1">Filtros:</label>
-                <Select
-                  id="multiFilterSelect"
-                  value={selectedFilters}
-                  onChange={(newValue, actionMeta) => {
-                    if (type === 'instruction_level') {
-                      // Para instruction_level, garantir que instruction_level esteja sempre selecionado
-                      const instructionLevelFilter = { value: 'instruction_level', label: 'Nível de Instrução (Obrigatório)' };
-
-                      if (newValue.length === 0) {
-                        setSelectedFilters([instructionLevelFilter]);
-                      } else if (!newValue.some(filter => filter.value === 'instruction_level')) {
-                        setSelectedFilters([instructionLevelFilter, ...newValue.slice(-1)]);
-                      } else {
-                        setSelectedFilters(newValue.slice(-3)); // Máximo 3 filtros
-                      }
-                    } else if (type === 'iliteracy_rate' || type === 'superior_education_conclusion_tax' || type === 'basic_education_conclusion') {
-                      // Para os novos tipos, permitir até 2 filtros sem obrigatoriedade
-                      if (newValue.length <= 2) {
-                        setSelectedFilters(newValue);
-                      } else {
-                        setSelectedFilters(newValue.slice(-2));
-                      }
-                    } else {
-                      const isHistoricalRange = yearRange[0] !== yearRange[1];
-                      if (isHistoricalRange) {
-                        setSelectedFilters(newValue.slice(-1));
-                      } else if (newValue.length <= 2) {
-                        setSelectedFilters(newValue);
-                      } else {
-                        setSelectedFilters(newValue.slice(-2));
-                      }
-                    }
-                  }}
-                  options={filterOptions}
-                  isMulti
-                  placeholder={yearRange[0] !== yearRange[1] ? "Selecione 1 filtro" : "Selecione até 2 filtros"}
-                  size="xs"
-                />
-              </div>
-
-              <div className="w-full lg:flex-1">
-                <label className="block text-sm font-medium text-gray-700 mb-1">Informações:</label>
-                <Box sx={{ 
-                  width: '100%',
-                  color: theme.palette.text.secondary,
-                  fontSize: '0.85em',
-                  padding: '10px',
-                  backgroundColor: '#f8f9fa',
-                  borderRadius: '8px',
-                  border: '1px solid #e9ecef',
-                  minHeight: '40px',
-                  display: 'flex',
-                  alignItems: 'center',
-                  wordWrap: 'break-word',
-                  overflowWrap: 'break-word'
-                }}>
-                  {type === 'pop_out_school'
-                    ? <span>Para população fora da escola, os dados estão disponíveis apenas para consulta consolidada do estado do Piauí <span style={{ color: '#ff6b6b' }}>e é obrigatório selecionar faixa etaria para consulta</span>.</span>
-                    : type === 'adjusted_liquid_frequency'
-                    ? <span>Para frequência líquida ajustada, os dados estão disponíveis apenas para consulta consolidada do estado do Piauí <span style={{ color: '#ff6b6b' }}>e é obrigatório selecionar faixa etaria para consulta</span>.</span>
-                    : type === 'iliteracy_rate'
-                    ? <span>Para taxa de analfabetismo, os dados estão disponíveis apenas para consulta consolidada do estado do Piauí. Você pode selecionar faixa etária e/ou localidade como filtros opcionais.</span>
-                    : type === 'superior_education_conclusion_tax'
-                    ? <span>Para taxa de conclusão do ensino superior, os dados estão disponíveis apenas para consulta consolidada do estado do Piauí. Você pode selecionar faixa etária e/ou localidade como filtros opcionais.</span>
-                    : type === 'basic_education_conclusion'
-                    ? <span>Para taxa de conclusão do ensino básico, os dados estão disponíveis apenas para consulta consolidada do estado do Piauí. Você pode selecionar faixa etária e/ou localidade como filtros opcionais.</span>
-                    : type === 'instruction_level'
-                    ? <span>Para nível de instrução, os dados estão disponíveis apenas para consulta consolidada do estado do Piauí <span style={{ color: '#ff6b6b' }}>e é obrigatório selecionar nível de instrução para consulta</span>. Você pode combinar com localidade e/ou faixa etária.</span>
-                    : <span>Selecione um tipo para ver as informações específicas.</span>}
-                </Box>
-              </div>
-            </div>
-          </div>
-
-          {/* Período - Todas as colunas, segunda linha */}
-          <div className="md:col-span-3">
-            <YearRangeSlider
-              minYear={getYearLimits.min}
-              maxYear={getYearLimits.max}
-              value={yearRange}
-              onChange={setYearRange}
-            />
-          </div>
-
-          {/* Botões - Ocupa todo o espaço da linha */}
-          <div className="md:col-span-3 flex flex-col justify-end">
-            <div className="flex flex-col sm:flex-row gap-3 justify-end items-end">
-              <Button
-                variant="contained"
-                color="primary"
-                onClick={handleFilterClick}
-                className="w-full sm:w-auto"
+        {/* Tipo + Filtros + Informações - Primeira linha */}
+        <div className="md:col-span-3">
+          <div className="flex flex-col lg:flex-row items-start gap-4">
+            <div className="w-full lg:flex-1">
+              <label
+                htmlFor="typeSelect"
+                className="block text-sm font-medium text-gray-700 mb-1"
               >
-                Filtrar
-              </Button>
-
-              <Button
-                style={{
-                  backgroundColor: '#f0f0f0',
-                  color: '#000',
+                Tipo:
+              </label>
+              <Select
+                id="typeSelect"
+                value={typeOptions.find((option) => option.value === type)}
+                onChange={(selectedOption) => {
+                  setType(selectedOption.value);
+                  setSelectedFilters([]);
                 }}
-                variant="contained"
-                onClick={handleClearFilters}
-                className="w-full sm:w-auto"
+                options={typeOptions}
+                placeholder="Selecione o tipo"
+                size="xs"
+              />
+            </div>
+
+            <div className="w-full lg:flex-1">
+              <label
+                htmlFor="multiFilterSelect"
+                className="block text-sm font-medium text-gray-700 mb-1"
               >
-                Limpar
-              </Button>
+                Filtros:
+              </label>
+              <Select
+                id="multiFilterSelect"
+                value={selectedFilters}
+                onChange={(newValue, actionMeta) => {
+                  if (type === "instruction_level") {
+                    // Para instruction_level, garantir que instruction_level esteja sempre selecionado
+                    const instructionLevelFilter = {
+                      value: "instruction_level",
+                      label: "Nível de Instrução (Obrigatório)",
+                    };
+
+                    if (newValue.length === 0) {
+                      setSelectedFilters([instructionLevelFilter]);
+                    } else if (
+                      !newValue.some(
+                        (filter) => filter.value === "instruction_level",
+                      )
+                    ) {
+                      setSelectedFilters([
+                        instructionLevelFilter,
+                        ...newValue.slice(-1),
+                      ]);
+                    } else {
+                      setSelectedFilters(newValue.slice(-3)); // Máximo 3 filtros
+                    }
+                  } else if (
+                    type === "iliteracy_rate" ||
+                    type === "superior_education_conclusion_tax" ||
+                    type === "basic_education_conclusion"
+                  ) {
+                    // Para os novos tipos, permitir até 2 filtros sem obrigatoriedade
+                    if (newValue.length <= 2) {
+                      setSelectedFilters(newValue);
+                    } else {
+                      setSelectedFilters(newValue.slice(-2));
+                    }
+                  } else {
+                    const isHistoricalRange = yearRange[0] !== yearRange[1];
+                    if (isHistoricalRange) {
+                      setSelectedFilters(newValue.slice(-1));
+                    } else if (newValue.length <= 2) {
+                      setSelectedFilters(newValue);
+                    } else {
+                      setSelectedFilters(newValue.slice(-2));
+                    }
+                  }
+                }}
+                options={filterOptions}
+                isMulti
+                placeholder={
+                  yearRange[0] !== yearRange[1]
+                    ? "Selecione 1 filtro"
+                    : "Selecione até 2 filtros"
+                }
+                size="xs"
+              />
+            </div>
+
+            <div className="w-full lg:flex-1">
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Informações:
+              </label>
+              <Box
+                sx={{
+                  width: "100%",
+                  color: theme.palette.text.secondary,
+                  fontSize: "0.85em",
+                  padding: "10px",
+                  backgroundColor: "#f8f9fa",
+                  borderRadius: "8px",
+                  border: "1px solid #e9ecef",
+                  minHeight: "40px",
+                  display: "flex",
+                  alignItems: "center",
+                  wordWrap: "break-word",
+                  overflowWrap: "break-word",
+                }}
+              >
+                {type === "pop_out_school" ? (
+                  <span>
+                    Para população fora da escola, os dados estão disponíveis
+                    apenas para consulta consolidada do estado do Piauí{" "}
+                    <span style={{ color: "#ff6b6b" }}>
+                      e é obrigatório selecionar faixa etaria para consulta
+                    </span>
+                    .
+                  </span>
+                ) : type === "adjusted_liquid_frequency" ? (
+                  <span>
+                    Para frequência líquida ajustada, os dados estão disponíveis
+                    apenas para consulta consolidada do estado do Piauí{" "}
+                    <span style={{ color: "#ff6b6b" }}>
+                      e é obrigatório selecionar faixa etaria para consulta
+                    </span>
+                    .
+                  </span>
+                ) : type === "iliteracy_rate" ? (
+                  <span>
+                    Para taxa de analfabetismo, os dados estão disponíveis
+                    apenas para consulta consolidada do estado do Piauí. Você
+                    pode selecionar faixa etária e/ou localidade como filtros
+                    opcionais.
+                  </span>
+                ) : type === "superior_education_conclusion_tax" ? (
+                  <span>
+                    Para taxa de conclusão do ensino superior, os dados estão
+                    disponíveis apenas para consulta consolidada do estado do
+                    Piauí. Você pode selecionar faixa etária e/ou localidade
+                    como filtros opcionais.
+                  </span>
+                ) : type === "basic_education_conclusion" ? (
+                  <span>
+                    Para taxa de conclusão do ensino básico, os dados estão
+                    disponíveis apenas para consulta consolidada do estado do
+                    Piauí. Você pode selecionar faixa etária e/ou localidade
+                    como filtros opcionais.
+                  </span>
+                ) : type === "instruction_level" ? (
+                  <span>
+                    Para nível de instrução, os dados estão disponíveis apenas
+                    para consulta consolidada do estado do Piauí{" "}
+                    <span style={{ color: "#ff6b6b" }}>
+                      e é obrigatório selecionar nível de instrução para
+                      consulta
+                    </span>
+                    . Você pode combinar com localidade e/ou faixa etária.
+                  </span>
+                ) : (
+                  <span>
+                    Selecione um tipo para ver as informações específicas.
+                  </span>
+                )}
+              </Box>
             </div>
           </div>
         </div>
 
+        {/* Período - Seleção de Anos (Substituindo o Slider) */}
+        <div className="md:col-span-3">
+          <div className="flex flex-col sm:flex-row gap-4 py-4">
+            <div className="flex-1">
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                De:
+              </label>
+              <Select
+                id="startYearSelect"
+                options={yearOptions}
+                value={yearOptions.find((opt) => opt.value === yearRange[0])}
+                onChange={(selected) =>
+                  setYearRange([selected.value, yearRange[1]])
+                }
+                size="xs"
+              />
+            </div>
+
+            <div className="flex-1">
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Até:
+              </label>
+              <Select
+                id="endYearSelect"
+                options={yearOptions}
+                value={yearOptions.find((opt) => opt.value === yearRange[1])}
+                onChange={(selected) =>
+                  setYearRange([yearRange[0], selected.value])
+                }
+                size="xs"
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Botões - Ocupa todo o espaço da linha */}
+        <div className="md:col-span-3 flex flex-col justify-end">
+          <div className="flex flex-col sm:flex-row gap-3 justify-end items-end">
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleFilterClick}
+              className="w-full sm:w-auto"
+            >
+              Filtrar
+            </Button>
+
+            <Button
+              style={{
+                backgroundColor: "#f0f0f0",
+                color: "#000",
+              }}
+              variant="contained"
+              onClick={handleClearFilters}
+              className="w-full sm:w-auto"
+            >
+              Limpar
+            </Button>
+          </div>
+        </div>
+      </div>
+
       <hr className="divider" />
 
-      {isLoading && (
-        <Loading />
-      )}
+      {isLoading && <Loading />}
       {error && (
         <div className="error-message">
           <p>{error}</p>
@@ -368,18 +504,19 @@ function FiltrosRateComponent() {
       )}
 
       {!isLoading && !error && !data && (
-        <Typography 
-          variant="body1" 
-          sx={{ 
-            textAlign: 'center',
-            fontSize: '18px',
-            fontWeight: 'bold',
-            margin: '20px auto',
-            maxWidth: '400px',
-            color: theme.palette.primary.main
+        <Typography
+          variant="body1"
+          sx={{
+            textAlign: "center",
+            fontSize: "18px",
+            fontWeight: "bold",
+            margin: "20px auto",
+            maxWidth: "400px",
+            color: theme.palette.primary.main,
           }}
         >
-          Selecione os filtros desejados e clique em "Filtrar" para montar uma consulta.
+          Selecione os filtros desejados e clique em "Filtrar" para montar uma
+          consulta.
         </Typography>
       )}
 


### PR DESCRIPTION
Educação:
Ajustado o link do card "Indicadores Educacionais" na página de seleção, que apontava para uma rota inexistente.
Removido o botão "Mais Filtros"
Substituído o YearRangeSlider (barra) por dois componentes Select ("De" e "Até") para seleção de série histórica em todos os filtros de Educação Básica, Superior e Indicadores.